### PR TITLE
Balance

### DIFF
--- a/Scripts/Auth/PlayerProfileSnapshot.cs
+++ b/Scripts/Auth/PlayerProfileSnapshot.cs
@@ -82,7 +82,7 @@ public static class PlayerItemSnapshotCodec
         if (item is Equipment equipment)
         {
             baseDict["equipment_type"] = equipment.EquipmentType.ToString();
-            baseDict["rarity"] = Math.Max(1, equipment.Rarity);
+            baseDict["rarity"] = EquipmentManager.ClampRarity(equipment.Rarity);
             baseDict["level_requirement"] = Math.Max(1, equipment.LevelRequirement);
             baseDict["source"] = equipment.Source ?? string.Empty;
             baseDict["sprite_path"] = NormalizeSpritePathForStorage(equipment.SpritePath, equipment.Sprite);
@@ -93,7 +93,7 @@ public static class PlayerItemSnapshotCodec
         if (item is Weapon weapon)
         {
             baseDict["weapon_type"] = weapon.WeaponType.ToString();
-            baseDict["rarity"] = Math.Max(1, weapon.Rarity);
+            baseDict["rarity"] = EquipmentManager.ClampRarity(weapon.Rarity);
             baseDict["level_requirement"] = Math.Max(1, weapon.LevelRequirement);
             baseDict["source"] = weapon.Source ?? string.Empty;
             baseDict["sprite_path"] = NormalizeSpritePathForStorage(weapon.SpritePath, weapon.Sprite);
@@ -139,7 +139,7 @@ public static class PlayerItemSnapshotCodec
                 Quantity = ReadInt(data, "quantity", 1, 1),
                 Price = ReadInt(data, "price", 0, 0),
                 EquipmentType = ReadEnum(ReadString(data, "equipment_type", "Other"), EquipmentType.Other),
-                Rarity = ReadInt(data, "rarity", 1, 1),
+                Rarity = EquipmentManager.ClampRarity(ReadInt(data, "rarity", 1, 1)),
                 LevelRequirement = ReadInt(data, "level_requirement", 1, 1),
                 Source = ReadString(data, "source", string.Empty),
                 SpritePath = NormalizeSpritePathForRuntime(ReadString(data, "sprite_path", string.Empty)),
@@ -159,7 +159,7 @@ public static class PlayerItemSnapshotCodec
                 Quantity = ReadInt(data, "quantity", 1, 1),
                 Price = ReadInt(data, "price", 0, 0),
                 WeaponType = ReadEnum(ReadString(data, "weapon_type", "Sword"), WeaponType.Sword),
-                Rarity = ReadInt(data, "rarity", 1, 1),
+                Rarity = EquipmentManager.ClampRarity(ReadInt(data, "rarity", 1, 1)),
                 LevelRequirement = ReadInt(data, "level_requirement", 1, 1),
                 Source = ReadString(data, "source", string.Empty),
                 SpritePath = NormalizeSpritePathForRuntime(ReadString(data, "sprite_path", string.Empty)),

--- a/Scripts/Auth/PlayerProfileSnapshot.cs
+++ b/Scripts/Auth/PlayerProfileSnapshot.cs
@@ -396,11 +396,17 @@ public static class PlayerItemSnapshotCodec
 
 public class PlayerProfileSnapshot
 {
+    private const string StatAllocationsKey = "stat_allocations";
+
     public int Level { get; set; } = 1;
     public int Experience { get; set; } = 0;
     public int HpMax { get; set; } = 100;
     public int HpCurrent { get; set; } = 100;
     public int Gold { get; set; } = 0;
+    public int StatAtkPoints { get; set; } = 0;
+    public int StatDefPoints { get; set; } = 0;
+    public int StatSpdPoints { get; set; } = 0;
+    public int StatVitPoints { get; set; } = 0;
     public bool Ignored { get; set; } = false;
     public string IgnoreReason { get; set; } = string.Empty;
     public bool HasInventoryItemsPayload { get; set; } = false;
@@ -448,6 +454,12 @@ public class PlayerProfileSnapshot
         {
             snapshot.HasEquippedItemsPayload = true;
             snapshot.EquippedItemsPayload = equippedDict;
+            snapshot.ReadStatAllocations(equippedDict);
+        }
+
+        if (data.Contains(StatAllocationsKey) && data[StatAllocationsKey] is Godot.Collections.Dictionary statDict)
+        {
+            snapshot.ReadStatAllocations(statDict);
         }
 
         if (data.Contains("skills") && data["skills"] is Godot.Collections.Array rawSkills)
@@ -510,6 +522,9 @@ public class PlayerProfileSnapshot
 
     public Godot.Collections.Dictionary ToUpdatePayload(string sessionId, int sequence)
     {
+        var equippedItems = EquippedItemsPayload ?? new Godot.Collections.Dictionary();
+        equippedItems[StatAllocationsKey] = BuildStatAllocationsPayload();
+
         return new Godot.Collections.Dictionary
         {
             ["session_id"] = sessionId ?? string.Empty,
@@ -522,9 +537,39 @@ public class PlayerProfileSnapshot
             ["class_name"] = string.IsNullOrWhiteSpace(ClassName) ? "adventurer" : ClassName,
             ["inventory_items"] = InventoryItems ?? new Godot.Collections.Array(),
             ["discarded_items"] = DiscardedItems ?? new Godot.Collections.Array(),
-            ["equipped_items"] = EquippedItemsPayload ?? new Godot.Collections.Dictionary(),
+            ["equipped_items"] = equippedItems,
             ["skills"] = EncodeSkills(Skills),
         };
+    }
+
+    private Godot.Collections.Dictionary BuildStatAllocationsPayload()
+    {
+        return new Godot.Collections.Dictionary
+        {
+            ["atk"] = Math.Max(0, StatAtkPoints),
+            ["def"] = Math.Max(0, StatDefPoints),
+            ["spd"] = Math.Max(0, StatSpdPoints),
+            ["vit"] = Math.Max(0, StatVitPoints),
+        };
+    }
+
+    private void ReadStatAllocations(Godot.Collections.Dictionary data)
+    {
+        if (data == null)
+        {
+            return;
+        }
+
+        Godot.Collections.Dictionary source = data;
+        if (data.Contains(StatAllocationsKey) && data[StatAllocationsKey] is Godot.Collections.Dictionary nested)
+        {
+            source = nested;
+        }
+
+        StatAtkPoints = ReadInt(source, "atk", StatAtkPoints, min: 0);
+        StatDefPoints = ReadInt(source, "def", StatDefPoints, min: 0);
+        StatSpdPoints = ReadInt(source, "spd", StatSpdPoints, min: 0);
+        StatVitPoints = ReadInt(source, "vit", StatVitPoints, min: 0);
     }
 
     private static string ReadString(Godot.Collections.Dictionary data, string key, string fallback)

--- a/Scripts/Characters/FireMonster.cs
+++ b/Scripts/Characters/FireMonster.cs
@@ -12,6 +12,16 @@ namespace QuestFantasy.Characters
         private const float BurnDurationSeconds = 15f;
         private const float BurnDamageMultiplier = 0.5f;
 
+        protected override float HpMultiplier
+        {
+            get { return 0.85f; }
+        }
+
+        protected override float AttackMultiplier
+        {
+            get { return 0.9f; }
+        }
+
         protected override void LoadTextures()
         {
             _standTexture = GD.Load<Texture>("res://Assets/FireMonster/fire_slime_stand.png");

--- a/Scripts/Characters/Monster.cs
+++ b/Scripts/Characters/Monster.cs
@@ -40,13 +40,13 @@ namespace QuestFantasy.Characters
         public int BaseAttack = 4;
 
         [Export]
-        public int AttackPerLevel = 1;
+        public float AttackPerLevel = 0.5f;
 
         [Export]
         public int BaseDefense = 0;
 
         [Export]
-        public int DefensePerTenLevels = 1;
+        public float DefensePerTenLevels = 0.5f;
 
         public int ExperienceReward { get; set; }
         public int LootGoldReward { get; set; }
@@ -583,6 +583,19 @@ namespace QuestFantasy.Characters
             get { return 1f; }
         }
 
+        private float GetDifficultyMultiplier()
+        {
+            DifficultyLevel mapDiff = _map != null ? _map.Difficulty : DifficultyLevel.Normal;
+            switch (mapDiff)
+            {
+                case DifficultyLevel.Easy: return 0.5f;
+                case DifficultyLevel.Normal: return 1.0f;
+                case DifficultyLevel.Hard: return 3.0f;
+                case DifficultyLevel.Nightmare: return 10.0f;
+                default: return 1.0f;
+            }
+        }
+
         private int GetReferenceLevel()
         {
             int playerLevel = _player != null ? (int)_player.Level : (int)Level;
@@ -593,19 +606,20 @@ namespace QuestFantasy.Characters
         {
             int baseHp = Math.Max(1, BaseHp);
             int hpPerLevel = Math.Max(0, HpPerLevel);
-            return Mathf.Max(1, Mathf.RoundToInt((baseHp + referenceLevel * hpPerLevel) * HpMultiplier));
+            return Mathf.Max(1, Mathf.RoundToInt((baseHp + referenceLevel * hpPerLevel) * HpMultiplier * GetDifficultyMultiplier()));
         }
 
         private int GetScaledAttack(int referenceLevel)
         {
             int baseAttack = Math.Max(1, BaseAttack);
-            int attackPerLevel = Math.Max(0, AttackPerLevel);
-            return Mathf.Max(1, Mathf.RoundToInt((baseAttack + referenceLevel * attackPerLevel) * AttackMultiplier));
+            float attackPerLevel = Math.Max(0, AttackPerLevel);
+            return Mathf.Max(1, Mathf.RoundToInt((baseAttack + referenceLevel * attackPerLevel) * AttackMultiplier * GetDifficultyMultiplier()));
         }
 
         private int GetScaledDefense(int referenceLevel)
         {
-            return Math.Max(0, BaseDefense) + Math.Max(0, referenceLevel / 10) * Math.Max(0, DefensePerTenLevels);
+            float baseDefense = Math.Max(0, BaseDefense) + Math.Max(0, referenceLevel / 10) * Math.Max(0, DefensePerTenLevels);
+            return Mathf.RoundToInt(baseDefense * GetDifficultyMultiplier());
         }
 
         protected virtual bool TryHandleSpecialBehavior(float delta, float distanceToPlayer)

--- a/Scripts/Characters/Monster.cs
+++ b/Scripts/Characters/Monster.cs
@@ -26,6 +26,28 @@ namespace QuestFantasy.Characters
 
         [Export]
         public int DropLevelOffset = 1;
+
+        [Export]
+        public float ItemDropChance = 0.5f;
+
+        [Export]
+        public int BaseHp = 40;
+
+        [Export]
+        public int HpPerLevel = 8;
+
+        [Export]
+        public int BaseAttack = 4;
+
+        [Export]
+        public int AttackPerLevel = 1;
+
+        [Export]
+        public int BaseDefense = 0;
+
+        [Export]
+        public int DefensePerTenLevels = 1;
+
         public int ExperienceReward { get; set; }
         public int LootGoldReward { get; set; }
 
@@ -206,9 +228,9 @@ namespace QuestFantasy.Characters
                 return;
             }
 
-            // Fixed for current assignment spec
-            Attributes.TotalAtk = 1;
-            Attributes.TotalDef = 0;
+            int referenceLevel = GetReferenceLevel();
+            Attributes.TotalAtk = GetScaledAttack(referenceLevel);
+            Attributes.TotalDef = GetScaledDefense(referenceLevel);
         }
 
         public override void TakeDamage(int damage, Character source = null)
@@ -541,9 +563,49 @@ namespace QuestFantasy.Characters
         {
             if (Attributes != null)
             {
-                Attributes.TotalAtk = 1;
-                Attributes.HP.SetMaxHPAndCurrentHP(50);
+                int referenceLevel = GetReferenceLevel();
+                Level = referenceLevel;
+                Attributes.TotalAtk = GetScaledAttack(referenceLevel);
+                Attributes.TotalDef = GetScaledDefense(referenceLevel);
+                int hp = GetScaledHp(referenceLevel);
+                Attributes.TotalVit = Mathf.Max(1, Mathf.CeilToInt(hp / 10f));
+                Attributes.HP.SetMaxHPAndCurrentHP(hp);
             }
+        }
+
+        protected virtual float HpMultiplier
+        {
+            get { return 1f; }
+        }
+
+        protected virtual float AttackMultiplier
+        {
+            get { return 1f; }
+        }
+
+        private int GetReferenceLevel()
+        {
+            int playerLevel = _player != null ? (int)_player.Level : (int)Level;
+            return Mathf.Max(1, playerLevel);
+        }
+
+        private int GetScaledHp(int referenceLevel)
+        {
+            int baseHp = Math.Max(1, BaseHp);
+            int hpPerLevel = Math.Max(0, HpPerLevel);
+            return Mathf.Max(1, Mathf.RoundToInt((baseHp + referenceLevel * hpPerLevel) * HpMultiplier));
+        }
+
+        private int GetScaledAttack(int referenceLevel)
+        {
+            int baseAttack = Math.Max(1, BaseAttack);
+            int attackPerLevel = Math.Max(0, AttackPerLevel);
+            return Mathf.Max(1, Mathf.RoundToInt((baseAttack + referenceLevel * attackPerLevel) * AttackMultiplier));
+        }
+
+        private int GetScaledDefense(int referenceLevel)
+        {
+            return Math.Max(0, BaseDefense) + Math.Max(0, referenceLevel / 10) * Math.Max(0, DefensePerTenLevels);
         }
 
         protected virtual bool TryHandleSpecialBehavior(float delta, float distanceToPlayer)
@@ -696,7 +758,7 @@ namespace QuestFantasy.Characters
             var coinDrop = new QuestFantasy.Items.CoinDrop();
             int pLevel = _player != null ? (int)_player.Level : (int)Level;
             DifficultyLevel mapDiff = _map != null ? _map.Difficulty : DifficultyLevel.Normal;
-            coinDrop.Initialize(pLevel, mapDiff, 0.1f, _player);
+            coinDrop.Initialize(pLevel, mapDiff, 0.3f, _player);
             coinDrop.Position = GlobalPosition + new Vector2((float)_random.NextDouble() * 40f - 20f, (float)_random.NextDouble() * 40f - 20f);
             parent.AddChild(coinDrop);
             GD.PrintS($"[Monster] Spawned Coin drop at {coinDrop.Position}");
@@ -707,88 +769,66 @@ namespace QuestFantasy.Characters
             // Find EquipmentManager early so consumable/ticket drops can match equipment scale
             var manager = FindEquipmentManager();
 
+            float itemDropChance = Mathf.Clamp(ItemDropChance, 0f, 1f);
+            if (rng.Randf() >= itemDropChance)
+            {
+                GD.PrintS("[Monster] Item drop roll failed.");
+                return;
+            }
+
+            Item itemDrop = RollSingleItemDrop(rng, manager, mapDiff);
+
+            if (itemDrop == null)
+            {
+                GD.PrintS("[Monster] Item drop roll passed, but no item was available.");
+                return;
+            }
+
+            float itemScale = manager != null ? manager.PickupSpriteScale : 0.5f;
+            var itemPos = GlobalPosition + new Vector2(rng.Randf() * 100f - 50f, rng.Randf() * 100f - 50f);
+            LootItemFactory.SpawnPickup(parent, itemDrop, itemPos, itemScale, "monster_item");
+            GD.PrintS($"[Monster] Spawned item drop: {itemDrop.Name} at {itemPos}");
+        }
+
+        private Item RollSingleItemDrop(RandomNumberGenerator rng, EquipmentManager manager, DifficultyLevel mapDiff)
+        {
             Item potionDrop = LootItemFactory.RollPotion(rng, 0.08f);
             if (potionDrop != null)
             {
-                var potionPos = GlobalPosition + new Vector2(rng.Randf() * 100f - 50f, rng.Randf() * 100f - 50f);
-                float scale = manager != null ? manager.PickupSpriteScale : 0.5f;
-                LootItemFactory.SpawnPickup(parent, potionDrop, potionPos, scale, "monster_potion");
-                GD.PrintS($"[Monster] Spawned potion drop: {potionDrop.Name} at {potionPos}");
+                return potionDrop;
             }
 
             Item ticketDrop = LootItemFactory.RollTicket(rng, mapDiff, 1f);
             if (ticketDrop != null)
             {
-                var ticketPos = GlobalPosition + new Vector2(rng.Randf() * 100f - 50f, rng.Randf() * 100f - 50f);
-                float tscale = manager != null ? manager.PickupSpriteScale : 0.5f;
-                LootItemFactory.SpawnPickup(parent, ticketDrop, ticketPos, tscale, "monster_ticket");
-                GD.PrintS($"[Monster] Spawned ticket drop: {ticketDrop.Name} at {ticketPos}");
-            }
-            if (manager == null)
-            {
-                GD.PrintS("[Monster] No EquipmentManager found; skipping equipment drops.");
-                return;
+                return ticketDrop;
             }
 
-            int minD = Math.Max(0, MinDrops);
-            int maxD = Math.Max(minD, MaxDrops);
-            int drops = rng.RandiRange(minD, maxD);
-            if (drops <= 0)
+            if (manager == null)
             {
-                return;
+                GD.PrintS("[Monster] No EquipmentManager found; skipping equipment item drop.");
+                return null;
             }
 
             int playerLevel = _player != null ? (int)_player.Level : (int)Level;
-            var options = manager.GetEquipmentSet(DropOptionCount, playerLevel, DropLevelOffset);
+            var options = manager.GetEquipmentSet(Math.Max(1, DropOptionCount), playerLevel, DropLevelOffset);
             var optList = new System.Collections.Generic.List<Item>();
-            foreach (var o in options)
+            foreach (var option in options)
             {
-                if (o is Item it) optList.Add(it);
+                if (option is Item item)
+                {
+                    optList.Add(item);
+                }
             }
 
             if (optList.Count == 0)
             {
-                GD.PrintS("[Monster] No equipment options available for drops.");
-                return;
+                GD.PrintS("[Monster] No equipment options available for item drop.");
+                return null;
             }
 
-            // Shuffle
-            var shuffled = new System.Collections.Generic.List<Item>(optList);
-            for (int s = shuffled.Count - 1; s > 0; s--)
-            {
-                int j = (int)rng.RandiRange(0, s);
-                var tmp = shuffled[s];
-                shuffled[s] = shuffled[j];
-                shuffled[j] = tmp;
-            }
-
-            int take = Math.Min(drops, shuffled.Count);
-            for (int i = 0; i < take; i++)
-            {
-                var it = shuffled[i];
-                if (it == null) continue;
-
-                var pickup = new EquipmentPickup();
-                pickup.ItemData = it;
-                // Try to use manager configured pickup scale
-                pickup.SpriteScale = manager.PickupSpriteScale;
-                var offset = new Vector2(rng.Randf() * 120f - 60f, rng.Randf() * 120f - 60f);
-                pickup.Position = GlobalPosition + offset;
-
-                string baseName = "equipment";
-                var spriteTex = (it is Equipment pe) ? pe.Sprite : (it is Weapon pw ? pw.Sprite : null);
-                if (spriteTex != null)
-                {
-                    var rp = spriteTex.ResourcePath;
-                    if (!string.IsNullOrEmpty(rp))
-                    {
-                        baseName = System.IO.Path.GetFileNameWithoutExtension(rp).Replace(' ', '_');
-                    }
-                }
-                pickup.Name = $"Pickup_{baseName}_monster_{i}";
-                parent.AddChild(pickup);
-                GD.PrintS($"[Monster] Spawned drop: {pickup.Name} at {pickup.Position}");
-            }
+            int index = rng.RandiRange(0, optList.Count - 1);
+            return optList[index];
         }
 
         private EquipmentManager FindEquipmentManager()

--- a/Scripts/Characters/NPC.cs
+++ b/Scripts/Characters/NPC.cs
@@ -119,6 +119,12 @@ namespace QuestFantasy.Characters
         {
             try
             {
+                if (InteractionButtonUI.IsSuppressed)
+                {
+                    SetInRangeState(false);
+                    return;
+                }
+
                 _nearbyPlayer = ResolveNearbyPlayer();
                 if (_nearbyPlayer == null)
                 {

--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -737,11 +737,18 @@ namespace QuestFantasy.Characters
                     continue;
                 }
 
+                float cdr = 0f;
+                if (Attributes != null)
+                {
+                    float spd = (float)Attributes.TotalSpd;
+                    cdr = 0.9f * (spd * spd) / (spd * spd + 5000f);
+                }
+
                 result.Add(new PlayerSkillSnapshot
                 {
                     SkillId = ResolveSkillId(skill),
                     Name = skill.Name,
-                    CooldownSeconds = skill.GetCooldownDuration(),
+                    CooldownSeconds = skill.GetCooldownDuration() * (1f - cdr),
                     RemainingCooldownSeconds = skill.CoolDown.RemainingTime,
                     DisplayOrder = i,
                 });

--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -55,6 +55,7 @@ namespace QuestFantasy.Characters
         private PlayerEquipmentSystem _equipmentSystem;
         private PlayerAnimationConfig _animationConfig;
         private PlayerConfigValidator.PlayerConfig _playerConfig;
+        private readonly Abilities _allocatedStatPoints = new Abilities();
 
         // Death state
         private Texture _deadTexture;
@@ -73,6 +74,12 @@ namespace QuestFantasy.Characters
         public int Gold => _inventorySystem?.Gold ?? 0;
         public Weapon EquippedWeapon => _equipmentSystem?.EquippedWeapon;
         public EquippedItems EquippedItems => _equipmentSystem?.EquippedItems;
+        public int AllocatedAtkPoints => _allocatedStatPoints.Atk;
+        public int AllocatedDefPoints => _allocatedStatPoints.Def;
+        public int AllocatedSpdPoints => _allocatedStatPoints.Spd;
+        public int AllocatedVitPoints => _allocatedStatPoints.Vit;
+        public int SpentStatPoints => _allocatedStatPoints.GetTotal();
+        public int AvailableStatPoints => Math.Max(0, (int)Math.Max(1, Level) - SpentStatPoints);
 
         // Events - delegated from subsystems
         public event Action<int> OnExperienceChanged;
@@ -80,6 +87,7 @@ namespace QuestFantasy.Characters
         public event Action<Item> OnInventoryChanged;
         public event Action<int> OnLevelChanged;
         public event Action<int, int> OnHpChanged;
+        public event Action OnStatPointsChanged;
         public event Action OnDied;
         public event Action<Vector2, string> OnRoomEntered;
 
@@ -291,10 +299,10 @@ namespace QuestFantasy.Characters
             var jobBonuses = CurrentJob?.BaseAbilities ?? new Abilities();
             var equipmentBonuses = _equipmentSystem?.GetAllEquipmentBonuses() ?? new Abilities();
 
-            Attributes.TotalAtk = jobBonuses.Atk + equipmentBonuses.Atk;
-            Attributes.TotalDef = jobBonuses.Def + equipmentBonuses.Def;
-            Attributes.TotalSpd = jobBonuses.Spd + equipmentBonuses.Spd;
-            Attributes.TotalVit = jobBonuses.Vit + equipmentBonuses.Vit;
+            Attributes.TotalAtk = jobBonuses.Atk + equipmentBonuses.Atk + _allocatedStatPoints.Atk;
+            Attributes.TotalDef = jobBonuses.Def + equipmentBonuses.Def + _allocatedStatPoints.Def;
+            Attributes.TotalSpd = jobBonuses.Spd + equipmentBonuses.Spd + _allocatedStatPoints.Spd;
+            Attributes.TotalVit = jobBonuses.Vit + equipmentBonuses.Vit + _allocatedStatPoints.Vit;
         }
 
         public override void TakeDamage(int damage, Character source = null)
@@ -461,6 +469,66 @@ namespace QuestFantasy.Characters
             OnLevelChanged?.Invoke(normalized);
         }
 
+        public bool AllocateStatPoint(string statKey)
+        {
+            if (AvailableStatPoints <= 0)
+            {
+                return false;
+            }
+
+            bool allocatedVit = false;
+            switch ((statKey ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "atk":
+                    _allocatedStatPoints.Atk += 1;
+                    break;
+                case "def":
+                    _allocatedStatPoints.Def += 1;
+                    break;
+                case "spd":
+                    _allocatedStatPoints.Spd += 1;
+                    break;
+                case "vit":
+                    _allocatedStatPoints.Vit += 1;
+                    allocatedVit = true;
+                    break;
+                default:
+                    GD.PrintErr($"[Player] Unknown stat allocation key: {statKey}");
+                    return false;
+            }
+
+            UpdateAttributes();
+            if (allocatedVit && Attributes?.HP != null)
+            {
+                int maxHp = Attributes.HP.MaxHP + GameConstants.PLAYER_HP_STAT_BONUS;
+                int currentHp = Attributes.HP.CurrentHP + GameConstants.PLAYER_HP_STAT_BONUS;
+                Attributes.HP.SetMaxHPAndCurrentHP(maxHp, currentHp);
+                OnHpChanged?.Invoke(Attributes.HP.CurrentHP, Attributes.HP.MaxHP);
+            }
+
+            OnStatPointsChanged?.Invoke();
+            return true;
+        }
+
+        public void ApplyStatAllocations(int atk, int def, int spd, int vit)
+        {
+            int remaining = Math.Max(1, (int)Math.Max(1, Level));
+            _allocatedStatPoints.Atk = ConsumeStatAllocation(Math.Max(0, atk), ref remaining);
+            _allocatedStatPoints.Def = ConsumeStatAllocation(Math.Max(0, def), ref remaining);
+            _allocatedStatPoints.Spd = ConsumeStatAllocation(Math.Max(0, spd), ref remaining);
+            _allocatedStatPoints.Vit = ConsumeStatAllocation(Math.Max(0, vit), ref remaining);
+
+            UpdateAttributes();
+            OnStatPointsChanged?.Invoke();
+        }
+
+        private static int ConsumeStatAllocation(int requested, ref int remaining)
+        {
+            int applied = Math.Min(requested, Math.Max(0, remaining));
+            remaining -= applied;
+            return applied;
+        }
+
         public void ApplyProfile(PlayerProfileSnapshot snapshot)
         {
             if (snapshot == null)
@@ -469,6 +537,11 @@ namespace QuestFantasy.Characters
             }
 
             SetLevel(snapshot.Level);
+            ApplyStatAllocations(
+                snapshot.StatAtkPoints,
+                snapshot.StatDefPoints,
+                snapshot.StatSpdPoints,
+                snapshot.StatVitPoints);
             Attributes?.HP?.SetMaxHPAndCurrentHP(snapshot.HpMax, snapshot.HpCurrent);
             _inventorySystem?.SetSnapshot(snapshot.Experience, snapshot.Gold);
 
@@ -542,6 +615,10 @@ namespace QuestFantasy.Characters
                 Gold = Gold,
                 HpMax = Attributes?.HP?.MaxHP ?? 100,
                 HpCurrent = Attributes?.HP?.CurrentHP ?? 100,
+                StatAtkPoints = _allocatedStatPoints.Atk,
+                StatDefPoints = _allocatedStatPoints.Def,
+                StatSpdPoints = _allocatedStatPoints.Spd,
+                StatVitPoints = _allocatedStatPoints.Vit,
                 Skills = GetSkillSnapshots().ToList(),
                 InventoryItems = PlayerItemSnapshotCodec.EncodeMany(_inventorySystem?.Inventory?.Items),
                 DiscardedItems = PlayerItemSnapshotCodec.EncodeMany(_inventorySystem?.Discarded?.Items),

--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -504,6 +504,7 @@ namespace QuestFantasy.Characters
             _animationController?.Revive();
             _respawnInvincibilityTimer = 3.0f;
             Modulate = new Color(1f, 0.9f, 0.4f, 1f);
+            EffectManager?.Clear(this);
             GD.Print("[Player] Respawned");
             Update();
         }
@@ -520,6 +521,7 @@ namespace QuestFantasy.Characters
             Attributes.HP.SetMaxHPAndCurrentHP(maxHp, maxHp);
             _animationController?.Revive();
             Modulate = new Color(1f, 1f, 1f, 1f);
+            EffectManager?.Clear(this);
         }
 
         public void SetLevel(int level)

--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -457,6 +457,20 @@ namespace QuestFantasy.Characters
             Update();
         }
 
+        public void RestoreFullHp()
+        {
+            if (Attributes?.HP == null)
+            {
+                return;
+            }
+
+            _isDead = false;
+            int maxHp = Attributes.HP.MaxHP;
+            Attributes.HP.SetMaxHPAndCurrentHP(maxHp, maxHp);
+            _animationController?.Revive();
+            Modulate = new Color(1f, 1f, 1f, 1f);
+        }
+
         public void SetLevel(int level)
         {
             int normalized = Mathf.Max(1, level);
@@ -520,6 +534,34 @@ namespace QuestFantasy.Characters
 
             UpdateAttributes();
             OnStatPointsChanged?.Invoke();
+        }
+
+        public bool ResetStatAllocations()
+        {
+            if (SpentStatPoints <= 0)
+            {
+                return false;
+            }
+
+            int removedHpBonus = _allocatedStatPoints.Vit * GameConstants.PLAYER_HP_STAT_BONUS;
+            int currentHp = Attributes?.HP?.CurrentHP ?? 0;
+            int currentMaxHp = Attributes?.HP?.MaxHP ?? 100;
+
+            _allocatedStatPoints.Atk = 0;
+            _allocatedStatPoints.Def = 0;
+            _allocatedStatPoints.Spd = 0;
+            _allocatedStatPoints.Vit = 0;
+
+            UpdateAttributes();
+
+            if (Attributes?.HP != null && removedHpBonus > 0)
+            {
+                int newMaxHp = Math.Max(1, currentMaxHp - removedHpBonus);
+                Attributes.HP.SetMaxHPAndCurrentHP(newMaxHp, Math.Min(currentHp, newMaxHp));
+            }
+
+            OnStatPointsChanged?.Invoke();
+            return true;
         }
 
         private static int ConsumeStatAllocation(int requested, ref int remaining)

--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -222,11 +222,8 @@ namespace QuestFantasy.Characters
             _deadTexture = GD.Load<Texture>("res://Assets/Characters/adventurer/down.png");
             _hitTexture = GD.Load<Texture>("res://Assets/Characters/adventurer/hit.png");
 
-            // Set stats according to requirements
-            if (Attributes != null)
-            {
-                Attributes.TotalAtk = 1;
-            }
+            ApplyClassStats(PlayerClass);
+            UpdateAttributes();
 
             Update();
         }
@@ -297,12 +294,52 @@ namespace QuestFantasy.Characters
             }
 
             var jobBonuses = CurrentJob?.BaseAbilities ?? new Abilities();
-            var equipmentBonuses = _equipmentSystem?.GetAllEquipmentBonuses() ?? new Abilities();
+            var equipmentBonuses = GetClassAdjustedEquipmentBonuses();
 
-            Attributes.TotalAtk = jobBonuses.Atk + equipmentBonuses.Atk + _allocatedStatPoints.Atk;
-            Attributes.TotalDef = jobBonuses.Def + equipmentBonuses.Def + _allocatedStatPoints.Def;
-            Attributes.TotalSpd = jobBonuses.Spd + equipmentBonuses.Spd + _allocatedStatPoints.Spd;
-            Attributes.TotalVit = jobBonuses.Vit + equipmentBonuses.Vit + _allocatedStatPoints.Vit;
+            int totalAtk = jobBonuses.Atk + equipmentBonuses.Atk + _allocatedStatPoints.Atk;
+            int totalDef = jobBonuses.Def + equipmentBonuses.Def + _allocatedStatPoints.Def;
+            int totalSpd = jobBonuses.Spd + equipmentBonuses.Spd + _allocatedStatPoints.Spd;
+            int totalVit = jobBonuses.Vit + equipmentBonuses.Vit + _allocatedStatPoints.Vit;
+
+            Attributes.Update(totalAtk, totalDef, totalSpd, totalVit);
+        }
+
+        private Abilities GetClassAdjustedEquipmentBonuses()
+        {
+            var bonuses = _equipmentSystem?.GetAllEquipmentBonuses() ?? new Abilities();
+            Weapon weapon = EquippedWeapon;
+            if (weapon?.WeaponAbilities == null || !IsPreferredWeaponForClass(PlayerClass, weapon.WeaponType))
+            {
+                return bonuses;
+            }
+
+            float extraRate = GameConstants.PLAYER_CLASS_WEAPON_MATCH_MULTIPLIER - 1f;
+            bonuses.Atk += Mathf.RoundToInt(weapon.WeaponAbilities.Atk * extraRate);
+            bonuses.Def += Mathf.RoundToInt(weapon.WeaponAbilities.Def * extraRate);
+            bonuses.Spd += Mathf.RoundToInt(weapon.WeaponAbilities.Spd * extraRate);
+            bonuses.Vit += Mathf.RoundToInt(weapon.WeaponAbilities.Vit * extraRate);
+            return bonuses;
+        }
+
+        private static bool IsPreferredWeaponForClass(PlayerClass cls, WeaponType weaponType)
+        {
+            switch (cls)
+            {
+                case PlayerClass.Archer:
+                    return weaponType == WeaponType.Bow;
+                case PlayerClass.Knight:
+                    return weaponType == WeaponType.Sword;
+                case PlayerClass.Mage:
+                    return weaponType == WeaponType.Staff;
+                default:
+                    return false;
+            }
+        }
+
+        private float GetEffectiveMoveSpeed()
+        {
+            int speedStat = Attributes?.TotalSpd ?? 0;
+            return Mathf.Max(1f, MoveSpeed + speedStat * SpeedMultiplier);
         }
 
         public override void TakeDamage(int damage, Character source = null)
@@ -322,7 +359,13 @@ namespace QuestFantasy.Characters
 
             _damageCooldownFrames = 6; // 0.1 seconds at 60 FPS processing
 
-            base.TakeDamage(damage, source);
+            int finalDamage = damage;
+            if (source != null && Attributes != null)
+            {
+                finalDamage = Mathf.Max(1, damage - Mathf.FloorToInt(Attributes.EffectiveDef * GameConstants.DEFENSE_DAMAGE_REDUCTION_FACTOR));
+            }
+
+            base.TakeDamage(finalDamage, source);
             if (!_isDead && Attributes?.HP != null && Attributes.HP.IsAlive)
             {
                 _animationController?.PlayHitAnimation(_hitTexture, 0.2f);
@@ -396,14 +439,22 @@ namespace QuestFantasy.Characters
                 _map,
                 movementInput,
                 GetCollisionBodySizePixels(),
-                MoveSpeed,
+                GetEffectiveMoveSpeed(),
                 delta);
 
             // 2. Handle animations
             _animationController.Update(movementInput, delta);
 
             // 3. Handle combat and skills
-            _combatController.HandleSkillInput(this, _map);
+            if (_map.CombatEnabled)
+            {
+                _combatController.HandleSkillInput(this, _map);
+            }
+            else
+            {
+                _inputHandler.ConsumeUiSkillActivation();
+                _inputHandler.ConsumeSkillActivationInput();
+            }
 
             // 4. Handle environmental interactions
             if (_map.HasNearbyBox(Position, out Vector2 boxWorld))
@@ -491,6 +542,8 @@ namespace QuestFantasy.Characters
             }
 
             bool allocatedVit = false;
+            int previousMaxHp = Attributes?.HP?.MaxHP ?? 0;
+            int previousCurrentHp = Attributes?.HP?.CurrentHP ?? 0;
             switch ((statKey ?? string.Empty).Trim().ToLowerInvariant())
             {
                 case "atk":
@@ -514,10 +567,11 @@ namespace QuestFantasy.Characters
             UpdateAttributes();
             if (allocatedVit && Attributes?.HP != null)
             {
-                int maxHp = Attributes.HP.MaxHP + GameConstants.PLAYER_HP_STAT_BONUS;
-                int currentHp = Attributes.HP.CurrentHP + GameConstants.PLAYER_HP_STAT_BONUS;
-                Attributes.HP.SetMaxHPAndCurrentHP(maxHp, currentHp);
-                OnHpChanged?.Invoke(Attributes.HP.CurrentHP, Attributes.HP.MaxHP);
+                int gainedHp = Math.Max(0, Attributes.HP.MaxHP - previousMaxHp);
+                if (gainedHp > 0)
+                {
+                    Attributes.HP.SetMaxHPAndCurrentHP(Attributes.HP.MaxHP, previousCurrentHp + gainedHp);
+                }
             }
 
             OnStatPointsChanged?.Invoke();
@@ -543,22 +597,12 @@ namespace QuestFantasy.Characters
                 return false;
             }
 
-            int removedHpBonus = _allocatedStatPoints.Vit * GameConstants.PLAYER_HP_STAT_BONUS;
-            int currentHp = Attributes?.HP?.CurrentHP ?? 0;
-            int currentMaxHp = Attributes?.HP?.MaxHP ?? 100;
-
             _allocatedStatPoints.Atk = 0;
             _allocatedStatPoints.Def = 0;
             _allocatedStatPoints.Spd = 0;
             _allocatedStatPoints.Vit = 0;
 
             UpdateAttributes();
-
-            if (Attributes?.HP != null && removedHpBonus > 0)
-            {
-                int newMaxHp = Math.Max(1, currentMaxHp - removedHpBonus);
-                Attributes.HP.SetMaxHPAndCurrentHP(newMaxHp, Math.Min(currentHp, newMaxHp));
-            }
 
             OnStatPointsChanged?.Invoke();
             return true;
@@ -936,6 +980,7 @@ namespace QuestFantasy.Characters
         public void SetClass(PlayerClass cls, bool rebuildSkills = true)
         {
             PlayerClass = cls;
+            ApplyClassStats(cls);
             GD.Print($"[Player] Class changed to {PlayerClassData.GetDisplayName(cls)}");
 
             ApplyClassSprites(cls);
@@ -945,8 +990,14 @@ namespace QuestFantasy.Characters
                 ApplyClassSkills(cls);
             }
 
+            UpdateAttributes();
             OnClassChanged?.Invoke(cls);
             Update();
+        }
+
+        private void ApplyClassStats(PlayerClass cls)
+        {
+            CurrentJob = PlayerClassData.CreateJob(cls);
         }
 
         /// <summary>

--- a/Scripts/Characters/PlayerSystems/PlayerInteractionController.cs
+++ b/Scripts/Characters/PlayerSystems/PlayerInteractionController.cs
@@ -43,6 +43,11 @@ namespace QuestFantasy.Characters.PlayerSystems
         /// </summary>
         public void HandleInteractionInput(Map map, Vector2 playerPosition)
         {
+            if (InteractionButtonUI.IsSuppressed)
+            {
+                return;
+            }
+
             bool keyPressed = _inputHandler.IsInteractPressed();
             bool buttonPressed = InteractionButtonUI.IsPressed();
 

--- a/Scripts/Characters/SpeedMonster.cs
+++ b/Scripts/Characters/SpeedMonster.cs
@@ -30,6 +30,16 @@ namespace QuestFantasy.Characters
         private bool _hasHitPlayerThisDash;
         private Texture _amassTexture;
 
+        protected override float HpMultiplier
+        {
+            get { return 0.9f; }
+        }
+
+        protected override float AttackMultiplier
+        {
+            get { return 1.1f; }
+        }
+
         protected override void LoadTextures()
         {
             _standTexture = GD.Load<Texture>("res://Assets/SpeedMonster/speed_slime_stand.png");

--- a/Scripts/Core/Data/Attributes/Skills.cs
+++ b/Scripts/Core/Data/Attributes/Skills.cs
@@ -75,7 +75,14 @@ namespace QuestFantasy.Core.Data.Attributes
                 return false;
 
             Effect(player, target);
-            CoolDown.Start(GetCooldownDuration());
+            float baseCooldown = GetCooldownDuration();
+            float cdr = 0f;
+            if (player != null && player.Attributes != null)
+            {
+                float spd = (float)player.Attributes.TotalSpd;
+                cdr = 0.9f * (spd * spd) / (spd * spd + 5000f);
+            }
+            CoolDown.Start(baseCooldown * (1f - cdr));
 
             // Render visual effect if renderer is available
             if (target != null && EffectRenderer != null)

--- a/Scripts/Core/Data/GameConstants.cs
+++ b/Scripts/Core/Data/GameConstants.cs
@@ -13,6 +13,9 @@ public static class GameConstants
     /// <summary>Conversion factor from speed stat points to pixels per second.</summary>
     public const float PLAYER_SPEED_TO_PIXELS_MULTIPLIER = 50f;
 
+    /// <summary>Max HP gained from each manually allocated HP point.</summary>
+    public const int PLAYER_HP_STAT_BONUS = 10;
+
     /// <summary>Default player body dimensions in tiles.</summary>
     public static readonly Vector2 PLAYER_BODY_SIZE_IN_TILES = new Vector2(1.0f, 1.9f);
 

--- a/Scripts/Core/Data/GameConstants.cs
+++ b/Scripts/Core/Data/GameConstants.cs
@@ -11,7 +11,10 @@ public static class GameConstants
     public const float PLAYER_DEFAULT_MOVE_SPEED = 240f;
 
     /// <summary>Conversion factor from speed stat points to pixels per second.</summary>
-    public const float PLAYER_SPEED_TO_PIXELS_MULTIPLIER = 50f;
+    public const float PLAYER_SPEED_TO_PIXELS_MULTIPLIER = 2f;
+
+    /// <summary>Multiplier applied to weapon bonuses when the weapon matches the player's class.</summary>
+    public const float PLAYER_CLASS_WEAPON_MATCH_MULTIPLIER = 1.5f;
 
     /// <summary>Max HP gained from each manually allocated HP point.</summary>
     public const int PLAYER_HP_STAT_BONUS = 10;

--- a/Scripts/Core/Data/Items/Equipment.cs
+++ b/Scripts/Core/Data/Items/Equipment.cs
@@ -162,6 +162,12 @@ namespace QuestFantasy.Core.Data.Items
             base.Use(player);
         }
 
+        public override bool CanUse(Player player)
+        {
+            return base.CanUse(player)
+                && player.Level >= Mathf.Max(1, LevelRequirement);
+        }
+
         public override Item Clone()
         {
             var clone = (Equipment)base.Clone();

--- a/Scripts/Core/Data/Items/Weapon.cs
+++ b/Scripts/Core/Data/Items/Weapon.cs
@@ -37,6 +37,12 @@ namespace QuestFantasy.Core.Data.Items
             base.Use(player);
         }
 
+        public override bool CanUse(Player player)
+        {
+            return base.CanUse(player)
+                && player.Level >= Mathf.Max(1, LevelRequirement);
+        }
+
         public override Item Clone()
         {
             var clone = (Weapon)base.Clone();

--- a/Scripts/Core/Data/PlayerClass.cs
+++ b/Scripts/Core/Data/PlayerClass.cs
@@ -192,7 +192,7 @@ namespace QuestFantasy.Core.Data
                     abilities.Set(20, 5, 5, 5);
                     break;
                 case PlayerClass.Archer:
-                    abilities.Set(8, 8, 10, 9);
+                    abilities.Set(8, 7, 13, 7);
                     break;
                 case PlayerClass.Knight:
                     abilities.Set(10, 10, 5, 10);

--- a/Scripts/Core/Data/PlayerClass.cs
+++ b/Scripts/Core/Data/PlayerClass.cs
@@ -189,16 +189,16 @@ namespace QuestFantasy.Core.Data
             switch (cls)
             {
                 case PlayerClass.Mage:
-                    abilities.Set(8, 5, 5, 8);
+                    abilities.Set(20, 5, 5, 5);
                     break;
                 case PlayerClass.Archer:
-                    abilities.Set(10, 6, 6, 9);
+                    abilities.Set(8, 8, 10, 9);
                     break;
                 case PlayerClass.Knight:
-                    abilities.Set(14, 11, 4, 14);
+                    abilities.Set(10, 10, 5, 10);
                     break;
                 default:
-                    abilities.Set(10, 8, 5, 10);
+                    abilities.Set(5, 5, 5, 5);
                     break;
             }
 

--- a/Scripts/Core/Data/PlayerClass.cs
+++ b/Scripts/Core/Data/PlayerClass.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
+using QuestFantasy.Core.Data.Attributes;
+
 namespace QuestFantasy.Core.Data
 {
     /// <summary>
@@ -178,6 +180,44 @@ namespace QuestFantasy.Core.Data
                 default:
                     return "The all-rounder.\nCommands sword, bow, and magic freely.";
             }
+        }
+
+        /// <summary>Returns the base stats for each class before equipment and free stat points.</summary>
+        public static Abilities GetBaseAbilities(PlayerClass cls)
+        {
+            var abilities = new Abilities();
+            switch (cls)
+            {
+                case PlayerClass.Mage:
+                    abilities.Set(8, 5, 5, 8);
+                    break;
+                case PlayerClass.Archer:
+                    abilities.Set(10, 6, 6, 9);
+                    break;
+                case PlayerClass.Knight:
+                    abilities.Set(14, 11, 4, 14);
+                    break;
+                default:
+                    abilities.Set(10, 8, 5, 10);
+                    break;
+            }
+
+            return abilities;
+        }
+
+        /// <summary>Creates the runtime job descriptor used by Player attribute calculation.</summary>
+        public static Jobs CreateJob(PlayerClass cls)
+        {
+            var abilities = GetBaseAbilities(cls);
+            var job = new Jobs();
+            job.Initialize(
+                GetDisplayName(cls),
+                GetDescription(cls),
+                abilities.Atk,
+                abilities.Def,
+                abilities.Spd,
+                abilities.Vit);
+            return job;
         }
 
         /// <summary>Returns the skill names shown in the class-select UI.</summary>

--- a/Scripts/Core/Data/Skills/IceSpearSkill.cs
+++ b/Scripts/Core/Data/Skills/IceSpearSkill.cs
@@ -33,7 +33,7 @@ namespace QuestFantasy.Core.Data.Skills
                 player,
                 target,
                 MaxRange,
-                onHitEffect: () => new FreezeEffect(1.0f), // 1 second freeze
+                onHitEffect: () => new FreezeEffect(2f), // 2 second freeze
                 onHitChance: 1.0f); // Always freeze
         }
     }

--- a/Scripts/Core/Data/Skills/SkillProjectileSpawner.cs
+++ b/Scripts/Core/Data/Skills/SkillProjectileSpawner.cs
@@ -250,6 +250,7 @@ namespace QuestFantasy.Core.Data.Skills
         private int _damageMax;
         private bool _isAoe;
         private float _aoeRadius;
+        private bool _isIceSpear = false;
         private Texture _projectileTexture;
         private Texture[] _flightFrames;
         private Texture[] _impactFrames;
@@ -529,10 +530,11 @@ namespace QuestFantasy.Core.Data.Skills
                 _damageMin = 5,
                 _damageMax = 9,
                 _isAoe = false,
+                _isIceSpear = true,
                 _onHitEffect = onHitEffect,
                 _onHitChance = onHitChance,
                 _projectileTexture = GD.Load<Texture>("res://Assets/SkillAnimation/ice_spear-1.png"),
-                _projectileScale = 0.3f,
+                _projectileScale = 0.22f,
                 _impactScale = 0.35f,
                 _flightFrameDuration = 0.1f,
                 _impactFrameDuration = 0.08f,
@@ -827,7 +829,31 @@ namespace QuestFantasy.Core.Data.Skills
             _impactTimer = 0f;
             _impactFrameIndex = 0;
 
-            if (_isAoe)
+            if (_isIceSpear)
+            {
+                if (directHitTarget != null)
+                {
+                    ApplyDamage(directHitTarget);
+                }
+
+                float iceAoeRadius = 50f;
+                foreach (Character enemy in EnumerateEnemyCharacters())
+                {
+                    if (enemy == null || enemy?.Attributes?.HP == null || !enemy.Attributes.HP.IsAlive)
+                        continue;
+
+                    if (enemy.GlobalPosition.DistanceTo(impactPosition) <= iceAoeRadius)
+                    {
+                        if (_onHitEffect != null)
+                        {
+                            StatusEffectHelper.TryApplyWithChance(enemy, _onHitEffect, _onHitChance);
+                        }
+                    }
+                }
+                _impactScale = 0.5f;
+                _impactFrameDuration = 0.8f;
+            }
+            else if (_isAoe)
             {
                 DamageInRadius(impactPosition, _aoeRadius);
             }
@@ -841,6 +867,10 @@ namespace QuestFantasy.Core.Data.Skills
                 _sprite.Texture = _impactFrames[0] ?? _sprite.Texture;
                 _sprite.Scale = new Vector2(_impactScale, _impactScale);
                 _sprite.Rotation = 0f;
+                if (_isIceSpear)
+                {
+                    _sprite.Modulate = new Color(1f, 1f, 1f, 0.7f);
+                }
             }
         }
 

--- a/Scripts/Environment/LobbyMap.cs
+++ b/Scripts/Environment/LobbyMap.cs
@@ -21,6 +21,7 @@ namespace QuestFantasy.Environment
             RoomsX = 1;
             RoomsY = 1;
             DisableRoomExits = true;  // Prevent any auto-teleportation
+            CombatEnabled = false;
 
             // Manually create the lobby (no procedural generation)
             CreateStaticLobby();

--- a/Scripts/Environment/Map/Map.cs
+++ b/Scripts/Environment/Map/Map.cs
@@ -39,6 +39,7 @@ public class Map : Node2D
     private static readonly RandomNumberGenerator _seedRandom = new RandomNumberGenerator();
     private static bool _seedRandomInitialized;
     public bool DisableRoomExits { get; set; } = false;  // Flag for lobby: disables room exit transitions
+    public bool CombatEnabled { get; set; } = true;
     public DifficultyLevel Difficulty { get; set; } = DifficultyLevel.Normal;
 
     public int WorldTileWidth => _data != null ? _data.WorldTileWidth : RoomsX * RoomTileSize;

--- a/Scripts/Items/CoinDrop.cs
+++ b/Scripts/Items/CoinDrop.cs
@@ -40,10 +40,10 @@ namespace QuestFantasy.Items
             float difficultyMultiplier = 1f;
             switch (difficulty)
             {
-                case DifficultyLevel.Easy: difficultyMultiplier = 0.5f; break;
+                case DifficultyLevel.Easy: difficultyMultiplier = 0.75f; break;
                 case DifficultyLevel.Normal: difficultyMultiplier = 1.0f; break;
-                case DifficultyLevel.Hard: difficultyMultiplier = 5.0f; break;
-                case DifficultyLevel.Nightmare: difficultyMultiplier = 20.0f; break;
+                case DifficultyLevel.Hard: difficultyMultiplier = 2.0f; break;
+                case DifficultyLevel.Nightmare: difficultyMultiplier = 4.0f; break;
             }
 
             var rng = new RandomNumberGenerator();

--- a/Scripts/Items/EquipmentManager.cs
+++ b/Scripts/Items/EquipmentManager.cs
@@ -16,7 +16,22 @@ public class EquipmentManager : Node
     public float PickupSpriteScale = 0.1f;
 
     [Export]
-    public float LevelScalingMultiplier = 1.0f; // scaling factor per equipment level (factor = 1 + level * multiplier)
+    public float LevelScalingMultiplier = 0.08f;
+
+    [Export]
+    public int BasicRarityWeight = 55;
+
+    [Export]
+    public int FineRarityWeight = 25;
+
+    [Export]
+    public int RareRarityWeight = 12;
+
+    [Export]
+    public int EpicRarityWeight = 6;
+
+    [Export]
+    public int LegendaryRarityWeight = 2;
 
     // Provide explicit asset lists per equipment category (no automatic discovery).
     [Export]
@@ -111,7 +126,17 @@ public class EquipmentManager : Node
     // Map rarity to a human-friendly prefix
     public string RarityPrefix(int rarity)
     {
-        switch (rarity)
+        return RarityDisplayName(rarity);
+    }
+
+    public static int ClampRarity(int rarity)
+    {
+        return Math.Max(1, Math.Min(5, rarity));
+    }
+
+    public static string RarityDisplayName(int rarity)
+    {
+        switch (ClampRarity(rarity))
         {
             case 1: return "Basic";
             case 2: return "Fine";
@@ -119,6 +144,32 @@ public class EquipmentManager : Node
             case 4: return "Epic";
             case 5: return "Legendary";
             default: return "Basic";
+        }
+    }
+
+    public static Color RarityColor(int rarity)
+    {
+        switch (ClampRarity(rarity))
+        {
+            case 1: return new Color(0.78f, 0.78f, 0.78f);
+            case 2: return new Color(0.34f, 0.80f, 0.34f);
+            case 3: return new Color(0.23f, 0.60f, 1.0f);
+            case 4: return new Color(0.75f, 0.38f, 1.0f);
+            case 5: return new Color(1.0f, 0.78f, 0.24f);
+            default: return new Color(0.95f, 0.95f, 0.95f);
+        }
+    }
+
+    public static float RarityStatMultiplier(int rarity)
+    {
+        switch (ClampRarity(rarity))
+        {
+            case 1: return 1.00f;
+            case 2: return 1.25f;
+            case 3: return 1.55f;
+            case 4: return 1.95f;
+            case 5: return 2.50f;
+            default: return 1.00f;
         }
     }
 
@@ -145,6 +196,7 @@ public class EquipmentManager : Node
         if (tex == null)
             return null;
 
+        rarity = ClampRarity(rarity);
         var cat = (category ?? "").Trim().ToLower();
         bool isWeaponCat = (cat == "sword" || cat == "bow" || cat == "staff" || cat == "blade" || cat == "dagger");
 
@@ -392,6 +444,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "bow", rarity);
@@ -410,6 +463,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "sword", rarity);
@@ -428,6 +482,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "staff", rarity);
@@ -446,6 +501,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "chestplate", rarity);
@@ -464,6 +520,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "gloves", rarity);
@@ -482,6 +539,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "helmet", rarity);
@@ -500,6 +558,7 @@ public class EquipmentManager : Node
                 var left = parts[0].Trim();
                 int rarity = 1;
                 if (parts.Length > 1) int.TryParse(parts[1].Trim(), out rarity);
+                rarity = ClampRarity(rarity);
                 Item it = null;
                 if (left.Contains("/") || left.StartsWith("Assets/") || left.StartsWith("res://"))
                     it = CreateFromAssetWithCategory(left, "shoes", rarity);
@@ -580,17 +639,17 @@ public class EquipmentManager : Node
         return null;
     }
 
-    // Return a set of items (Equipment or Weapon). By default selects base rarity==1 items
-    // and sets their LevelRequirement based on playerLevel +/- levelOffset.
+    // Return a set of items (Equipment or Weapon). Uses loaded assets as templates,
+    // then rolls an equipment level and one of five rarity tiers for each generated item.
     public System.Collections.Generic.List<Item> GetEquipmentSet(int count, int playerLevel, int levelOffset = 0)
     {
         var all = LoadAllFromFolder();
         var candidates = new System.Collections.Generic.List<Item>();
         foreach (var it in all)
         {
-            if (it is Equipment e && e.Rarity == 1)
+            if (it is Equipment)
                 candidates.Add(it);
-            else if (it is Weapon w && w.Rarity == 1)
+            else if (it is Weapon)
                 candidates.Add(it);
         }
 
@@ -611,25 +670,16 @@ public class EquipmentManager : Node
                 eq.EquipmentType = se.EquipmentType;
                 eq.EquipmentAbilities = new Abilities();
                 eq.EquipmentAbilities.Set(se.EquipmentAbilities?.Atk ?? 0, se.EquipmentAbilities?.Def ?? 0, se.EquipmentAbilities?.Spd ?? 0, se.EquipmentAbilities?.Vit ?? 0);
-                eq.Rarity = se.Rarity;
+                eq.Rarity = RollRarity();
                 eq.Sprite = se.Sprite;
-                eq.Name = se.Name;
                 eq.SpritePath = se.SpritePath;
                 eq.Source = se.Source;
-                eq.Price = se.Price;
 
-                int minLevel = Math.Max(1, playerLevel - levelOffset);
-                int maxLevel = Math.Max(1, playerLevel + levelOffset);
-                int chosen = minLevel;
-                if (maxLevel > minLevel)
-                    chosen = (int)Math.Floor(GD.Randf() * (maxLevel - minLevel + 1)) + minLevel;
+                int chosen = RollEquipmentLevel(playerLevel, levelOffset);
                 eq.LevelRequirement = chosen;
-                // Scale abilities by factor = 1 + LevelRequirement * LevelScalingMultiplier
-                float factor = 1f + eq.LevelRequirement * LevelScalingMultiplier;
-                eq.EquipmentAbilities.Atk = (int)System.Math.Max(0, System.Math.Round(eq.EquipmentAbilities.Atk * factor));
-                eq.EquipmentAbilities.Def = (int)System.Math.Max(0, System.Math.Round(eq.EquipmentAbilities.Def * factor));
-                eq.EquipmentAbilities.Spd = (int)System.Math.Max(0, System.Math.Round(eq.EquipmentAbilities.Spd * factor));
-                eq.EquipmentAbilities.Vit = (int)System.Math.Max(0, System.Math.Round(eq.EquipmentAbilities.Vit * factor));
+                eq.Name = BuildGeneratedName(eq);
+                eq.Price = CalculateGeneratedPrice(se.Price, eq.LevelRequirement, eq.Rarity);
+                ApplyGeneratedScaling(eq.EquipmentAbilities, eq.LevelRequirement, eq.Rarity);
                 result.Add(eq);
             }
             else if (src is Weapon sw)
@@ -638,30 +688,113 @@ public class EquipmentManager : Node
                 w.WeaponType = sw.WeaponType;
                 w.WeaponAbilities = new Abilities();
                 w.WeaponAbilities.Set(sw.WeaponAbilities?.Atk ?? 0, sw.WeaponAbilities?.Def ?? 0, sw.WeaponAbilities?.Spd ?? 0, sw.WeaponAbilities?.Vit ?? 0);
-                w.Rarity = sw.Rarity;
+                w.Rarity = RollRarity();
                 w.Sprite = sw.Sprite;
-                w.Name = sw.Name;
                 w.SpritePath = sw.SpritePath;
                 w.Source = sw.Source;
-                w.Price = sw.Price;
 
-                int minLevel = Math.Max(1, playerLevel - levelOffset);
-                int maxLevel = Math.Max(1, playerLevel + levelOffset);
-                int chosen = minLevel;
-                if (maxLevel > minLevel)
-                    chosen = (int)Math.Floor(GD.Randf() * (maxLevel - minLevel + 1)) + minLevel;
+                int chosen = RollEquipmentLevel(playerLevel, levelOffset);
                 w.LevelRequirement = chosen;
-                // Scale abilities by factor = 1 + LevelRequirement * LevelScalingMultiplier
-                float wfactor = 1f + w.LevelRequirement * LevelScalingMultiplier;
-                w.WeaponAbilities.Atk = (int)System.Math.Max(0, System.Math.Round(w.WeaponAbilities.Atk * wfactor));
-                w.WeaponAbilities.Def = (int)System.Math.Max(0, System.Math.Round(w.WeaponAbilities.Def * wfactor));
-                w.WeaponAbilities.Spd = (int)System.Math.Max(0, System.Math.Round(w.WeaponAbilities.Spd * wfactor));
-                w.WeaponAbilities.Vit = (int)System.Math.Max(0, System.Math.Round(w.WeaponAbilities.Vit * wfactor));
+                w.Name = BuildGeneratedName(w);
+                w.Price = CalculateGeneratedPrice(sw.Price, w.LevelRequirement, w.Rarity);
+                ApplyGeneratedScaling(w.WeaponAbilities, w.LevelRequirement, w.Rarity);
                 result.Add(w);
             }
         }
 
         return result;
+    }
+
+    private int RollRarity()
+    {
+        int[] weights =
+        {
+            Math.Max(0, BasicRarityWeight),
+            Math.Max(0, FineRarityWeight),
+            Math.Max(0, RareRarityWeight),
+            Math.Max(0, EpicRarityWeight),
+            Math.Max(0, LegendaryRarityWeight)
+        };
+
+        int total = 0;
+        foreach (int weight in weights)
+        {
+            total += weight;
+        }
+
+        if (total <= 0)
+        {
+            return 1;
+        }
+
+        int roll = (int)Math.Floor(GD.Randf() * total);
+        int accumulated = 0;
+        for (int i = 0; i < weights.Length; i++)
+        {
+            accumulated += weights[i];
+            if (roll < accumulated)
+            {
+                return i + 1;
+            }
+        }
+
+        return 1;
+    }
+
+    private int RollEquipmentLevel(int playerLevel, int levelOffset)
+    {
+        int minLevel = Math.Max(1, playerLevel - levelOffset);
+        int maxLevel = Math.Max(1, playerLevel + levelOffset);
+        if (maxLevel <= minLevel)
+        {
+            return minLevel;
+        }
+
+        return (int)Math.Floor(GD.Randf() * (maxLevel - minLevel + 1)) + minLevel;
+    }
+
+    private void ApplyGeneratedScaling(Abilities abilities, int levelRequirement, int rarity)
+    {
+        if (abilities == null)
+        {
+            return;
+        }
+
+        abilities.Atk = ScaleGeneratedStat(abilities.Atk, levelRequirement, rarity);
+        abilities.Def = ScaleGeneratedStat(abilities.Def, levelRequirement, rarity);
+        abilities.Spd = ScaleGeneratedStat(abilities.Spd, levelRequirement, rarity);
+        abilities.Vit = ScaleGeneratedStat(abilities.Vit, levelRequirement, rarity);
+    }
+
+    private int ScaleGeneratedStat(int baseValue, int levelRequirement, int rarity)
+    {
+        if (baseValue <= 0)
+        {
+            return 0;
+        }
+
+        float levelFactor = 1f + Math.Max(0, levelRequirement - 1) * Math.Max(0f, LevelScalingMultiplier);
+        float rarityFactor = RarityStatMultiplier(rarity);
+        return (int)Math.Max(1, Math.Round(baseValue * levelFactor * rarityFactor));
+    }
+
+    private int CalculateGeneratedPrice(int basePrice, int levelRequirement, int rarity)
+    {
+        float rarityFactor = RarityStatMultiplier(rarity);
+        float price = (Math.Max(10, basePrice) + Math.Max(1, levelRequirement) * 6) * rarityFactor;
+        return (int)Math.Max(1, Math.Round(price));
+    }
+
+    private string BuildGeneratedName(Equipment equipment)
+    {
+        string category = equipment == null ? "Equipment" : equipment.EquipmentType.ToString();
+        return CombineToDisplayName(RarityDisplayName(equipment?.Rarity ?? 1), CategoryDisplayName(category));
+    }
+
+    private string BuildGeneratedName(Weapon weapon)
+    {
+        string category = weapon == null ? "Weapon" : weapon.WeaponType.ToString();
+        return CombineToDisplayName(RarityDisplayName(weapon?.Rarity ?? 1), CategoryDisplayName(category));
     }
 
     // Save an Equipment resource with a specified file name (without extension) under res://Items/Generated/

--- a/Scripts/Items/EquipmentManager.cs
+++ b/Scripts/Items/EquipmentManager.cs
@@ -16,7 +16,7 @@ public class EquipmentManager : Node
     public float PickupSpriteScale = 0.1f;
 
     [Export]
-    public float LevelScalingMultiplier = 0.08f;
+    public float LevelScalingMultiplier = 0.03f;
 
     [Export]
     public int BasicRarityWeight = 55;
@@ -165,10 +165,10 @@ public class EquipmentManager : Node
         switch (ClampRarity(rarity))
         {
             case 1: return 1.00f;
-            case 2: return 1.25f;
-            case 3: return 1.55f;
-            case 4: return 1.95f;
-            case 5: return 2.50f;
+            case 2: return 1.20f;
+            case 3: return 1.50f;
+            case 4: return 1.90f;
+            case 5: return 2.40f;
             default: return 1.00f;
         }
     }
@@ -639,9 +639,7 @@ public class EquipmentManager : Node
         return null;
     }
 
-    // Return a set of items (Equipment or Weapon). Uses loaded assets as templates,
-    // then rolls an equipment level and one of five rarity tiers for each generated item.
-    public System.Collections.Generic.List<Item> GetEquipmentSet(int count, int playerLevel, int levelOffset = 0)
+    private System.Collections.Generic.List<Item> GetEquipmentCandidates()
     {
         var all = LoadAllFromFolder();
         var candidates = new System.Collections.Generic.List<Item>();
@@ -653,6 +651,14 @@ public class EquipmentManager : Node
                 candidates.Add(it);
         }
 
+        return candidates;
+    }
+
+    // Return a set of items (Equipment or Weapon). Uses loaded assets as templates,
+    // then rolls an equipment level and one of five rarity tiers for each generated item.
+    public System.Collections.Generic.List<Item> GetEquipmentSet(int count, int playerLevel, int levelOffset = 0)
+    {
+        var candidates = GetEquipmentCandidates();
         var result = new System.Collections.Generic.List<Item>();
         if (candidates.Count == 0 || count <= 0)
             return result;
@@ -663,46 +669,148 @@ public class EquipmentManager : Node
             if (idx < 0) idx = 0;
             if (idx >= candidates.Count) idx = candidates.Count - 1;
 
-            var src = candidates[idx];
-            if (src is Equipment se)
+            var generated = CreateGeneratedItem(candidates[idx], playerLevel, levelOffset);
+            if (generated != null)
             {
-                var eq = new Equipment();
-                eq.EquipmentType = se.EquipmentType;
-                eq.EquipmentAbilities = new Abilities();
-                eq.EquipmentAbilities.Set(se.EquipmentAbilities?.Atk ?? 0, se.EquipmentAbilities?.Def ?? 0, se.EquipmentAbilities?.Spd ?? 0, se.EquipmentAbilities?.Vit ?? 0);
-                eq.Rarity = RollRarity();
-                eq.Sprite = se.Sprite;
-                eq.SpritePath = se.SpritePath;
-                eq.Source = se.Source;
-
-                int chosen = RollEquipmentLevel(playerLevel, levelOffset);
-                eq.LevelRequirement = chosen;
-                eq.Name = BuildGeneratedName(eq);
-                eq.Price = CalculateGeneratedPrice(se.Price, eq.LevelRequirement, eq.Rarity);
-                ApplyGeneratedScaling(eq.EquipmentAbilities, eq.LevelRequirement, eq.Rarity);
-                result.Add(eq);
-            }
-            else if (src is Weapon sw)
-            {
-                var w = new Weapon();
-                w.WeaponType = sw.WeaponType;
-                w.WeaponAbilities = new Abilities();
-                w.WeaponAbilities.Set(sw.WeaponAbilities?.Atk ?? 0, sw.WeaponAbilities?.Def ?? 0, sw.WeaponAbilities?.Spd ?? 0, sw.WeaponAbilities?.Vit ?? 0);
-                w.Rarity = RollRarity();
-                w.Sprite = sw.Sprite;
-                w.SpritePath = sw.SpritePath;
-                w.Source = sw.Source;
-
-                int chosen = RollEquipmentLevel(playerLevel, levelOffset);
-                w.LevelRequirement = chosen;
-                w.Name = BuildGeneratedName(w);
-                w.Price = CalculateGeneratedPrice(sw.Price, w.LevelRequirement, w.Rarity);
-                ApplyGeneratedScaling(w.WeaponAbilities, w.LevelRequirement, w.Rarity);
-                result.Add(w);
+                result.Add(generated);
             }
         }
 
         return result;
+    }
+
+    public System.Collections.Generic.List<Item> GetShopEquipmentSet(int count, int playerLevel, int levelOffset = 2)
+    {
+        var candidates = GetEquipmentCandidates();
+        var result = new System.Collections.Generic.List<Item>();
+        if (candidates.Count == 0 || count <= 0)
+        {
+            return result;
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            int idx = (int)Math.Floor(GD.Randf() * candidates.Count);
+            if (idx < 0) idx = 0;
+            if (idx >= candidates.Count) idx = candidates.Count - 1;
+
+            var generated = CreateGeneratedItem(candidates[idx], playerLevel, levelOffset);
+            if (generated != null)
+            {
+                result.Add(generated);
+            }
+        }
+
+        if (result.Count > 0 && !ContainsRareOrBetter(result))
+        {
+            int idx = (int)Math.Floor(GD.Randf() * candidates.Count);
+            if (idx < 0) idx = 0;
+            if (idx >= candidates.Count) idx = candidates.Count - 1;
+
+            var guaranteedRare = CreateGeneratedItem(candidates[idx], playerLevel, levelOffset, 3);
+            if (guaranteedRare != null)
+            {
+                result[result.Count - 1] = guaranteedRare;
+            }
+        }
+
+        foreach (Item item in result)
+        {
+            ApplyShopPrice(item);
+        }
+
+        return result;
+    }
+
+    private Item CreateGeneratedItem(Item src, int playerLevel, int levelOffset, int forcedRarity = 0)
+    {
+        if (src is Equipment se)
+        {
+            var eq = new Equipment();
+            eq.EquipmentType = se.EquipmentType;
+            eq.EquipmentAbilities = new Abilities();
+            eq.EquipmentAbilities.Set(se.EquipmentAbilities?.Atk ?? 0, se.EquipmentAbilities?.Def ?? 0, se.EquipmentAbilities?.Spd ?? 0, se.EquipmentAbilities?.Vit ?? 0);
+            eq.Rarity = forcedRarity > 0 ? ClampRarity(forcedRarity) : RollRarity();
+            eq.Sprite = se.Sprite;
+            eq.SpritePath = se.SpritePath;
+            eq.Source = se.Source;
+
+            int chosen = RollEquipmentLevel(playerLevel, levelOffset);
+            eq.LevelRequirement = chosen;
+            eq.Name = BuildGeneratedName(eq);
+            eq.Price = CalculateGeneratedPrice(se.Price, eq.LevelRequirement, eq.Rarity);
+            ApplyGeneratedScaling(eq.EquipmentAbilities, eq.LevelRequirement, eq.Rarity);
+            return eq;
+        }
+
+        if (src is Weapon sw)
+        {
+            var w = new Weapon();
+            w.WeaponType = sw.WeaponType;
+            w.WeaponAbilities = new Abilities();
+            w.WeaponAbilities.Set(sw.WeaponAbilities?.Atk ?? 0, sw.WeaponAbilities?.Def ?? 0, sw.WeaponAbilities?.Spd ?? 0, sw.WeaponAbilities?.Vit ?? 0);
+            w.Rarity = forcedRarity > 0 ? ClampRarity(forcedRarity) : RollRarity();
+            w.Sprite = sw.Sprite;
+            w.SpritePath = sw.SpritePath;
+            w.Source = sw.Source;
+
+            int chosen = RollEquipmentLevel(playerLevel, levelOffset);
+            w.LevelRequirement = chosen;
+            w.Name = BuildGeneratedName(w);
+            w.Price = CalculateGeneratedPrice(sw.Price, w.LevelRequirement, w.Rarity);
+            ApplyGeneratedScaling(w.WeaponAbilities, w.LevelRequirement, w.Rarity);
+            return w;
+        }
+
+        return null;
+    }
+
+    private static bool ContainsRareOrBetter(System.Collections.Generic.IEnumerable<Item> items)
+    {
+        if (items == null)
+        {
+            return false;
+        }
+
+        foreach (Item item in items)
+        {
+            if (GetItemRarity(item) >= 3)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int GetItemRarity(Item item)
+    {
+        if (item is Equipment equipment)
+        {
+            return ClampRarity(equipment.Rarity);
+        }
+
+        if (item is Weapon weapon)
+        {
+            return ClampRarity(weapon.Rarity);
+        }
+
+        return 1;
+    }
+
+    private static int GetItemLevelRequirement(Item item)
+    {
+        if (item is Equipment equipment)
+        {
+            return Math.Max(1, equipment.LevelRequirement);
+        }
+
+        if (item is Weapon weapon)
+        {
+            return Math.Max(1, weapon.LevelRequirement);
+        }
+
+        return 1;
     }
 
     private int RollRarity()
@@ -783,6 +891,32 @@ public class EquipmentManager : Node
         float rarityFactor = RarityStatMultiplier(rarity);
         float price = (Math.Max(10, basePrice) + Math.Max(1, levelRequirement) * 6) * rarityFactor;
         return (int)Math.Max(1, Math.Round(price));
+    }
+
+    private static void ApplyShopPrice(Item item)
+    {
+        if (item == null)
+        {
+            return;
+        }
+
+        int rarity = GetItemRarity(item);
+        int levelRequirement = GetItemLevelRequirement(item);
+        item.Price = GetShopPriceByRarity(rarity, levelRequirement);
+    }
+
+    public static int GetShopPriceByRarity(int rarity, int levelRequirement = 1)
+    {
+        int levelMultiplier = Math.Max(1, (Math.Max(1, levelRequirement) + 9) / 10);
+        switch (ClampRarity(rarity))
+        {
+            case 1: return 10 * levelMultiplier;
+            case 2: return 100 * levelMultiplier;
+            case 3: return 1000 * levelMultiplier;
+            case 4: return 10000 * levelMultiplier;
+            case 5: return 100000 * levelMultiplier;
+            default: return 10 * levelMultiplier;
+        }
     }
 
     private string BuildGeneratedName(Equipment equipment)

--- a/Scripts/Prototype/LobbyManager.cs
+++ b/Scripts/Prototype/LobbyManager.cs
@@ -39,6 +39,11 @@ namespace QuestFantasy.Prototype
         private readonly List<NPC> _lobbyNpcs = new List<NPC>();
         private Player _sharedPlayer;
         private Player _classSelectTarget;
+        private const int BlacksmithShopItemCount = 9;
+        private const int BlacksmithShopLevelOffset = 2;
+        private const int BlacksmithRefreshBaseCost = 50;
+        private const int BlacksmithRefreshCostPerLevel = 8;
+        private static List<Item> _blacksmithStock;
 
         public void Initialize(Player sharedPlayer, AuthApiClient apiClient = null, string authToken = null)
         {
@@ -187,7 +192,7 @@ namespace QuestFantasy.Prototype
             {
                 if (role == NpcRole.Blacksmith)
                 {
-                    npc.SetShopInventory(CreateBlacksmithStock());
+                    npc.SetShopInventory(GetBlacksmithStock(_sharedPlayer ?? _player));
                 }
                 else if (string.Equals(entityName, "Poet", StringComparison.OrdinalIgnoreCase)
                          || string.Equals(entityName, "Trader", StringComparison.OrdinalIgnoreCase))
@@ -242,10 +247,59 @@ namespace QuestFantasy.Prototype
             GD.Print($"[Lobby] Shop requested from {npc.EntityName}. Stock count: {npc.GetShopItems().Count}");
         }
 
-        private IEnumerable<Item> CreateBlacksmithStock()
+        private int GetShopRefreshCost(NPC npc, Player player)
         {
-            var stock = new List<Item>();
+            if (npc == null || npc.Role != NpcRole.Blacksmith)
+            {
+                return 0;
+            }
 
+            int playerLevel = Math.Max(1, (int)(player?.Level ?? _player?.Level ?? 1));
+            return BlacksmithRefreshBaseCost + playerLevel * BlacksmithRefreshCostPerLevel;
+        }
+
+        private bool OnShopRefreshRequested(NPC npc, Player player)
+        {
+            if (npc == null || player == null || npc.Role != NpcRole.Blacksmith)
+            {
+                return false;
+            }
+
+            int cost = GetShopRefreshCost(npc, player);
+            if (!player.SpendGold(cost))
+            {
+                return false;
+            }
+
+            _blacksmithStock = CreateBlacksmithStock(player);
+            npc.SetShopInventory(_blacksmithStock);
+            SyncRequested?.Invoke();
+            return true;
+        }
+
+        private List<Item> GetBlacksmithStock(Player player)
+        {
+            if (_blacksmithStock == null || _blacksmithStock.Count == 0)
+            {
+                _blacksmithStock = CreateBlacksmithStock(player);
+            }
+
+            return _blacksmithStock;
+        }
+
+        private List<Item> CreateBlacksmithStock(Player player)
+        {
+            int playerLevel = Math.Max(1, (int)(player?.Level ?? _player?.Level ?? 1));
+            var generatedStock = _equipmentFactory.GetShopEquipmentSet(
+                BlacksmithShopItemCount,
+                playerLevel,
+                BlacksmithShopLevelOffset);
+            if (generatedStock.Count > 0)
+            {
+                return generatedStock;
+            }
+
+            var stock = new List<Item>();
             AddIfNotNull(stock, _equipmentFactory.CreateFromAssetWithCategory("Assets/Equipments/sword/basic-sword.png", "sword", 1));
             AddIfNotNull(stock, _equipmentFactory.CreateFromAssetWithCategory("Assets/Equipments/chestplate/basic-chestplate.png", "chestplate", 1));
             AddIfNotNull(stock, _equipmentFactory.CreateFromAssetWithCategory("Assets/Equipments/gloves/basic-gloves.png", "gloves", 1));
@@ -301,6 +355,8 @@ namespace QuestFantasy.Prototype
             _shopUI = new NpcShopUI();
             AddChild(_shopUI);
             _shopUI.Closed += OnShopClosed;
+            _shopUI.RefreshCostRequested += GetShopRefreshCost;
+            _shopUI.RefreshRequested += OnShopRefreshRequested;
         }
 
         private void SetupMarketplaceUI()

--- a/Scripts/Prototype/LobbyManager.cs
+++ b/Scripts/Prototype/LobbyManager.cs
@@ -38,6 +38,7 @@ namespace QuestFantasy.Prototype
         private readonly EquipmentManager _equipmentFactory = new EquipmentManager();
         private readonly List<NPC> _lobbyNpcs = new List<NPC>();
         private Player _sharedPlayer;
+        private Player _classSelectTarget;
 
         public void Initialize(Player sharedPlayer, AuthApiClient apiClient = null, string authToken = null)
         {
@@ -314,11 +315,12 @@ namespace QuestFantasy.Prototype
             AddChild(_classSelectUI);
             _classSelectUI.ClassSelected += OnClassSelected;
             _classSelectUI.SkillLoadoutChanged += OnSkillLoadoutChanged;
+            _classSelectUI.StatPointRequested += OnStatPointRequested;
         }
 
         private void OnSkillLoadoutChanged(List<string> orderedSkillIds)
         {
-            Player target = _player;
+            Player target = _classSelectTarget ?? _player;
             if (target == null)
             {
                 return;
@@ -337,17 +339,29 @@ namespace QuestFantasy.Prototype
             }
 
             Player target = player ?? _player;
+            _classSelectTarget = target;
             PlayerClass current = target?.PlayerClass ?? PlayerClass.Adventurer;
             int level = (int)(target?.Level ?? 1);
             var equippedSkills = target?.GetEquippedSkillIds();
 
-            _classSelectUI.Show(current, level, equippedSkills);
+            _classSelectUI.Show(
+                current,
+                level,
+                equippedSkills,
+                target?.Attributes?.TotalAtk ?? 0,
+                target?.Attributes?.TotalDef ?? 0,
+                target?.Attributes?.TotalSpd ?? 0,
+                target?.Attributes?.HP?.MaxHP ?? 0,
+                target?.AllocatedAtkPoints ?? 0,
+                target?.AllocatedDefPoints ?? 0,
+                target?.AllocatedSpdPoints ?? 0,
+                target?.AllocatedVitPoints ?? 0);
             GD.Print($"[Lobby] Class selector opened by {npc.EntityName}. Current class: {current}, Player Level: {level}");
         }
 
         private void OnClassSelected(PlayerClass newClass)
         {
-            Player target = _player;
+            Player target = _classSelectTarget ?? _player;
             if (target == null)
             {
                 return;
@@ -356,6 +370,24 @@ namespace QuestFantasy.Prototype
             target.SetClass(newClass);
             GD.Print($"[Lobby] Player class set to {newClass}");
             ClassChangeRequested?.Invoke(newClass);
+        }
+
+        private bool OnStatPointRequested(string statKey)
+        {
+            Player target = _classSelectTarget ?? _player;
+            if (target == null)
+            {
+                return false;
+            }
+
+            bool applied = target.AllocateStatPoint(statKey);
+            if (applied)
+            {
+                GD.Print($"[Lobby] Allocated stat point to {statKey}. Remaining: {target.AvailableStatPoints}");
+                SyncRequested?.Invoke();
+            }
+
+            return applied;
         }
 
         private void OnShopClosed()

--- a/Scripts/Prototype/LobbyManager.cs
+++ b/Scripts/Prototype/LobbyManager.cs
@@ -98,6 +98,7 @@ namespace QuestFantasy.Prototype
             GD.Print("[Lobby] Player spawned at: " + _player.Position);
 
             _player.SetMap(_lobbyMap);
+            _player.RestoreFullHp();
 
             // Set camera bounds to entire lobby with padding
             float lobbyWidth = _lobbyMap.WorldPixelWidth;
@@ -316,6 +317,7 @@ namespace QuestFantasy.Prototype
             _classSelectUI.ClassSelected += OnClassSelected;
             _classSelectUI.SkillLoadoutChanged += OnSkillLoadoutChanged;
             _classSelectUI.StatPointRequested += OnStatPointRequested;
+            _classSelectUI.StatPointsResetRequested += OnStatPointsResetRequested;
         }
 
         private void OnSkillLoadoutChanged(List<string> orderedSkillIds)
@@ -388,6 +390,24 @@ namespace QuestFantasy.Prototype
             }
 
             return applied;
+        }
+
+        private bool OnStatPointsResetRequested()
+        {
+            Player target = _classSelectTarget ?? _player;
+            if (target == null)
+            {
+                return false;
+            }
+
+            bool reset = target.ResetStatAllocations();
+            if (reset)
+            {
+                GD.Print($"[Lobby] Reset stat allocations. Available: {target.AvailableStatPoints}");
+                SyncRequested?.Invoke();
+            }
+
+            return reset;
         }
 
         private void OnShopClosed()

--- a/Scripts/UI/BackpackUI.cs
+++ b/Scripts/UI/BackpackUI.cs
@@ -5,6 +5,7 @@ using Godot;
 
 using QuestFantasy.Characters;
 using QuestFantasy.Core.Data.Items;
+using QuestFantasy.UI;
 
 // Equipment slot definition
 public struct EquipSlotDef
@@ -83,6 +84,7 @@ public class BackpackUI : CanvasLayer
     private int _selectedGlobalIndex = -1;
     private BackpackViewMode _viewMode = BackpackViewMode.Gear;
     private bool _viewDirty = true;
+    private bool _interactionButtonSuppressed = false;
     private int _lastItemCount = -1;
     private int _lastGold = -1;
 
@@ -149,6 +151,8 @@ public class BackpackUI : CanvasLayer
         {
             _player.OnGoldChanged -= HandleGoldChanged;
         }
+
+        SetInteractionButtonSuppressed(false);
     }
 
     public void SetGameplayVisible(bool visible)
@@ -537,6 +541,7 @@ public class BackpackUI : CanvasLayer
         _panelRoot.Visible = visible;
         if (visible)
         {
+            SetInteractionButtonSuppressed(true);
             _viewDirty = true;
             SyncRequested?.Invoke();   // Ask Main to sync so items get their instance_id.
             RefreshView();
@@ -544,6 +549,25 @@ public class BackpackUI : CanvasLayer
         else
         {
             EquipmentPreview.Instance?.HidePreview();
+            SetInteractionButtonSuppressed(false);
+        }
+    }
+
+    private void SetInteractionButtonSuppressed(bool suppressed)
+    {
+        if (_interactionButtonSuppressed == suppressed)
+        {
+            return;
+        }
+
+        _interactionButtonSuppressed = suppressed;
+        if (suppressed)
+        {
+            InteractionButtonUI.PushSuppression();
+        }
+        else
+        {
+            InteractionButtonUI.PopSuppression();
         }
     }
 

--- a/Scripts/UI/BackpackUI.cs
+++ b/Scripts/UI/BackpackUI.cs
@@ -57,7 +57,6 @@ public class BackpackUI : CanvasLayer
     private Label _statAtkValueLabel;
     private Label _statDefValueLabel;
     private Label _statSpdValueLabel;
-    private Label _statVitValueLabel;
     private GridContainer _grid;
     private CenterContainer _gridCenter;
     private Label _pageLabel;
@@ -459,7 +458,6 @@ public class BackpackUI : CanvasLayer
         _statAtkValueLabel = AddStatRow(statsContent, "ATK", new Color(1f, 0.78f, 0.48f));
         _statDefValueLabel = AddStatRow(statsContent, "DEF", new Color(0.68f, 0.86f, 1f));
         _statSpdValueLabel = AddStatRow(statsContent, "SPD", new Color(0.62f, 1f, 0.78f));
-        _statVitValueLabel = AddStatRow(statsContent, "VIT", new Color(0.95f, 0.74f, 1f));
 
         _panelRoot.AddChild(_statsPanel);
     }
@@ -596,7 +594,7 @@ public class BackpackUI : CanvasLayer
 
         if (_player == null || _player.Attributes == null)
         {
-            SetStatValues("--", "--", "--", "--", "--", "--");
+            SetStatValues("--", "--", "--", "--", "--");
             return;
         }
 
@@ -610,18 +608,16 @@ public class BackpackUI : CanvasLayer
             hpText,
             FormatEffectiveStat(attributes.EffectiveAtk, attributes.TotalAtk),
             FormatEffectiveStat(attributes.EffectiveDef, attributes.TotalDef),
-            attributes.TotalSpd.ToString(),
-            attributes.TotalVit.ToString());
+            attributes.TotalSpd.ToString());
     }
 
-    private void SetStatValues(string level, string hp, string atk, string def, string spd, string vit)
+    private void SetStatValues(string level, string hp, string atk, string def, string spd)
     {
         _statLevelValueLabel.Text = level;
         _statHpValueLabel.Text = hp;
         _statAtkValueLabel.Text = atk;
         _statDefValueLabel.Text = def;
         _statSpdValueLabel.Text = spd;
-        _statVitValueLabel.Text = vit;
     }
 
     private string FormatEffectiveStat(int effectiveValue, int totalValue)

--- a/Scripts/UI/BackpackUI.cs
+++ b/Scripts/UI/BackpackUI.cs
@@ -51,6 +51,13 @@ public class BackpackUI : CanvasLayer
     private Control _panelRoot;
     private TextureRect _panelBackground;
     private Label _moneyValueLabel;
+    private PanelContainer _statsPanel;
+    private Label _statLevelValueLabel;
+    private Label _statHpValueLabel;
+    private Label _statAtkValueLabel;
+    private Label _statDefValueLabel;
+    private Label _statSpdValueLabel;
+    private Label _statVitValueLabel;
     private GridContainer _grid;
     private CenterContainer _gridCenter;
     private Label _pageLabel;
@@ -109,6 +116,10 @@ public class BackpackUI : CanvasLayer
         if (_viewDirty || itemCount != _lastItemCount || gold != _lastGold)
         {
             RefreshView();
+        }
+        else
+        {
+            RefreshStatsPanel();
         }
 
         if (!IsMouseHoveringAnyBackpackSlot())
@@ -269,6 +280,8 @@ public class BackpackUI : CanvasLayer
         };
         _panelRoot.AddChild(_panelBackground);
 
+        BuildStatsPanel();
+
         var content = new VBoxContainer
         {
             AnchorLeft = 0f,
@@ -389,6 +402,102 @@ public class BackpackUI : CanvasLayer
         content.AddChild(footer);
     }
 
+    private void BuildStatsPanel()
+    {
+        _statsPanel = new PanelContainer
+        {
+            AnchorLeft = 0f,
+            AnchorRight = 0f,
+            AnchorTop = 0f,
+            AnchorBottom = 0f,
+            MarginLeft = -72f,
+            MarginTop = 122f,
+            MarginRight = 56f,
+            MarginBottom = 314f,
+            MouseFilter = Control.MouseFilterEnum.Stop,
+        };
+
+        var panelStyle = new StyleBoxFlat
+        {
+            BgColor = new Color(0.08f, 0.09f, 0.14f, 0.84f),
+            BorderColor = new Color(0.72f, 0.86f, 1f, 0.72f),
+            BorderWidthTop = 2,
+            BorderWidthRight = 2,
+            BorderWidthBottom = 2,
+            BorderWidthLeft = 2,
+            CornerRadiusTopLeft = 6,
+            CornerRadiusTopRight = 6,
+            CornerRadiusBottomLeft = 6,
+            CornerRadiusBottomRight = 6,
+            ContentMarginLeft = 10,
+            ContentMarginRight = 10,
+            ContentMarginTop = 8,
+            ContentMarginBottom = 8,
+        };
+        _statsPanel.AddStyleboxOverride("panel", panelStyle);
+
+        var statsContent = new VBoxContainer
+        {
+            SizeFlagsHorizontal = (int)Control.SizeFlags.ExpandFill,
+            SizeFlagsVertical = (int)Control.SizeFlags.ExpandFill,
+        };
+        statsContent.AddConstantOverride("separation", 3);
+        _statsPanel.AddChild(statsContent);
+
+        var title = new Label
+        {
+            Text = "STATS",
+            Align = Label.AlignEnum.Center,
+            RectMinSize = new Vector2(0f, 20f),
+        };
+        title.AddColorOverride("font_color", new Color(0.82f, 0.92f, 1f));
+        title.AddColorOverride("font_color_shadow", new Color(0f, 0f, 0f, 0.75f));
+        statsContent.AddChild(title);
+
+        _statLevelValueLabel = AddStatRow(statsContent, "LV", new Color(1f, 0.92f, 0.45f));
+        _statHpValueLabel = AddStatRow(statsContent, "HP", new Color(1f, 0.58f, 0.58f));
+        _statAtkValueLabel = AddStatRow(statsContent, "ATK", new Color(1f, 0.78f, 0.48f));
+        _statDefValueLabel = AddStatRow(statsContent, "DEF", new Color(0.68f, 0.86f, 1f));
+        _statSpdValueLabel = AddStatRow(statsContent, "SPD", new Color(0.62f, 1f, 0.78f));
+        _statVitValueLabel = AddStatRow(statsContent, "VIT", new Color(0.95f, 0.74f, 1f));
+
+        _panelRoot.AddChild(_statsPanel);
+    }
+
+    private Label AddStatRow(VBoxContainer parent, string statName, Color valueColor)
+    {
+        var row = new HBoxContainer
+        {
+            SizeFlagsHorizontal = (int)Control.SizeFlags.ExpandFill,
+            RectMinSize = new Vector2(0f, 20f),
+        };
+        row.AddConstantOverride("separation", 6);
+
+        var nameLabel = new Label
+        {
+            Text = statName,
+            RectMinSize = new Vector2(36f, 18f),
+            Align = Label.AlignEnum.Left,
+            Valign = Label.VAlign.Center,
+        };
+        nameLabel.AddColorOverride("font_color", new Color(0.75f, 0.78f, 0.86f));
+        row.AddChild(nameLabel);
+
+        var valueLabel = new Label
+        {
+            Text = "--",
+            Align = Label.AlignEnum.Right,
+            Valign = Label.VAlign.Center,
+            SizeFlagsHorizontal = (int)Control.SizeFlags.ExpandFill,
+        };
+        valueLabel.AddColorOverride("font_color", valueColor);
+        valueLabel.AddColorOverride("font_color_shadow", new Color(0f, 0f, 0f, 0.8f));
+        row.AddChild(valueLabel);
+
+        parent.AddChild(row);
+        return valueLabel;
+    }
+
     private void EnsureToggleInputAction()
     {
         if (!InputMap.HasAction("toggle_inventory"))
@@ -445,6 +554,7 @@ public class BackpackUI : CanvasLayer
         if (_player == null)
         {
             _moneyValueLabel.Text = "0";
+            RefreshStatsPanel();
             _cachedItems.Clear();
             RebuildSlots(_cachedItems);
             RebuildEquipSlots();
@@ -472,8 +582,53 @@ public class BackpackUI : CanvasLayer
         _viewDirty = false;
 
         UpdateModeControls();
+        RefreshStatsPanel();
         RebuildSlots(_cachedItems);
         RebuildEquipSlots();
+    }
+
+    private void RefreshStatsPanel()
+    {
+        if (_statLevelValueLabel == null)
+        {
+            return;
+        }
+
+        if (_player == null || _player.Attributes == null)
+        {
+            SetStatValues("--", "--", "--", "--", "--", "--");
+            return;
+        }
+
+        var attributes = _player.Attributes;
+        string hpText = attributes.HP != null
+            ? $"{attributes.HP.CurrentHP}/{attributes.HP.MaxHP}"
+            : "--";
+
+        SetStatValues(
+            Math.Max(1L, _player.Level).ToString(),
+            hpText,
+            FormatEffectiveStat(attributes.EffectiveAtk, attributes.TotalAtk),
+            FormatEffectiveStat(attributes.EffectiveDef, attributes.TotalDef),
+            attributes.TotalSpd.ToString(),
+            attributes.TotalVit.ToString());
+    }
+
+    private void SetStatValues(string level, string hp, string atk, string def, string spd, string vit)
+    {
+        _statLevelValueLabel.Text = level;
+        _statHpValueLabel.Text = hp;
+        _statAtkValueLabel.Text = atk;
+        _statDefValueLabel.Text = def;
+        _statSpdValueLabel.Text = spd;
+        _statVitValueLabel.Text = vit;
+    }
+
+    private string FormatEffectiveStat(int effectiveValue, int totalValue)
+    {
+        return effectiveValue == totalValue
+            ? totalValue.ToString()
+            : $"{effectiveValue} ({totalValue})";
     }
 
     private void RebuildEquipSlots()

--- a/Scripts/UI/BackpackUI.cs
+++ b/Scripts/UI/BackpackUI.cs
@@ -696,8 +696,9 @@ public class BackpackUI : CanvasLayer
         };
 
         Color borderCol = hasItem
-            ? new Color(0.55f, 0.75f, 1f, 0.9f)
+            ? GetItemBorderColor(equipped)
             : new Color(0.25f, 0.25f, 0.35f, 0.7f);
+        int borderWidth = hasItem ? 2 : 1;
 
         var style = new StyleBoxFlat
         {
@@ -705,10 +706,10 @@ public class BackpackUI : CanvasLayer
                 ? new Color(0.12f, 0.15f, 0.25f, 0.9f)
                 : new Color(0.06f, 0.07f, 0.12f, 0.7f),
             BorderColor = borderCol,
-            BorderWidthTop = 1,
-            BorderWidthBottom = 1,
-            BorderWidthLeft = 1,
-            BorderWidthRight = 1,
+            BorderWidthTop = borderWidth,
+            BorderWidthBottom = borderWidth,
+            BorderWidthLeft = borderWidth,
+            BorderWidthRight = borderWidth,
             CornerRadiusTopLeft = 6,
             CornerRadiusTopRight = 6,
             CornerRadiusBottomLeft = 6,
@@ -848,6 +849,12 @@ public class BackpackUI : CanvasLayer
 
         if (item is Weapon weapon)
         {
+            if (!CanEquipItem(weapon, out string reason))
+            {
+                GD.Print($"[BackpackUI] Cannot equip weapon: {reason}");
+                return;
+            }
+
             // If weapon already equipped, swap back to inventory
             Weapon oldWeapon = _player.EquippedWeapon;
             _player.RemoveItem(item);
@@ -863,6 +870,12 @@ public class BackpackUI : CanvasLayer
             if (eq.EquipmentType == EquipmentType.None || eq.EquipmentType == EquipmentType.Other)
             {
                 GD.Print("[BackpackUI] Cannot equip item with no valid slot.");
+                return;
+            }
+
+            if (!CanEquipItem(eq, out string reason))
+            {
+                GD.Print($"[BackpackUI] Cannot equip armor: {reason}");
                 return;
             }
 
@@ -909,6 +922,9 @@ public class BackpackUI : CanvasLayer
 
     private Control BuildSlot(int globalIndex, Item item)
     {
+        bool isSelected = globalIndex == _selectedGlobalIndex;
+        int borderWidth = isSelected ? 3 : GetItemBorderWidth(item);
+
         var frame = new PanelContainer
         {
             RectMinSize = new Vector2(SlotSize, SlotSize),
@@ -918,13 +934,11 @@ public class BackpackUI : CanvasLayer
         var style = new StyleBoxFlat
         {
             BgColor = new Color(0.10f, 0.11f, 0.16f, 0.87f),
-            BorderColor = globalIndex == _selectedGlobalIndex
-                ? new Color(1f, 0.88f, 0.35f, 1f)
-                : new Color(0.3f, 0.36f, 0.45f, 0.95f),
-            BorderWidthTop = globalIndex == _selectedGlobalIndex ? 2 : 1,
-            BorderWidthRight = globalIndex == _selectedGlobalIndex ? 2 : 1,
-            BorderWidthBottom = globalIndex == _selectedGlobalIndex ? 2 : 1,
-            BorderWidthLeft = globalIndex == _selectedGlobalIndex ? 2 : 1,
+            BorderColor = GetItemBorderColor(item),
+            BorderWidthTop = borderWidth,
+            BorderWidthRight = borderWidth,
+            BorderWidthBottom = borderWidth,
+            BorderWidthLeft = borderWidth,
             CornerRadiusTopLeft = 6,
             CornerRadiusTopRight = 6,
             CornerRadiusBottomLeft = 6,
@@ -975,6 +989,67 @@ public class BackpackUI : CanvasLayer
         frame.Connect("mouse_exited", this, nameof(OnSlotMouseExited));
 
         return frame;
+    }
+
+    private Color GetItemBorderColor(Item item)
+    {
+        if (item is Equipment equipment)
+        {
+            return EquipmentManager.RarityColor(equipment.Rarity);
+        }
+
+        if (item is Weapon weapon)
+        {
+            return EquipmentManager.RarityColor(weapon.Rarity);
+        }
+
+        return new Color(0.3f, 0.36f, 0.45f, 0.95f);
+    }
+
+    private int GetItemBorderWidth(Item item)
+    {
+        return item is Equipment || item is Weapon ? 2 : 1;
+    }
+
+    private bool CanEquipItem(Item item, out string reason)
+    {
+        reason = string.Empty;
+        if (_player == null)
+        {
+            reason = "No player available.";
+            return false;
+        }
+
+        if (item is Equipment equipment)
+        {
+            if (equipment.EquipmentType == EquipmentType.None || equipment.EquipmentType == EquipmentType.Other)
+            {
+                reason = "Invalid equipment slot.";
+                return false;
+            }
+
+            if (!equipment.CanUse(_player))
+            {
+                reason = $"Requires Lv.{Math.Max(1, equipment.LevelRequirement)}.";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (item is Weapon weapon)
+        {
+            if (!weapon.CanUse(_player))
+            {
+                reason = $"Requires Lv.{Math.Max(1, weapon.LevelRequirement)}.";
+                return false;
+            }
+
+            return true;
+        }
+
+        reason = "Item is not equippable.";
+        return false;
     }
 
     private Texture GetItemTexture(Item item)
@@ -1035,7 +1110,37 @@ public class BackpackUI : CanvasLayer
             return $"{ticket.Name}\n{ticket.Difficulty} entry ticket\n{idLine}";
         }
 
+        if (item is Equipment equipment)
+        {
+            return $"{equipment.Name}\n{BuildEquipmentMeta(equipment.Rarity, equipment.LevelRequirement, equipment.EquipmentType.ToString())}\n{BuildEquipmentStats(equipment.EquipmentAbilities)}\n{idLine}";
+        }
+
+        if (item is Weapon weapon)
+        {
+            return $"{weapon.Name}\n{BuildEquipmentMeta(weapon.Rarity, weapon.LevelRequirement, weapon.WeaponType.ToString())}\n{BuildEquipmentStats(weapon.WeaponAbilities)}\n{idLine}";
+        }
+
         return $"{item.Name}\n{idLine}";
+    }
+
+    private string BuildEquipmentMeta(int rarity, int levelRequirement, string category)
+    {
+        string rarityName = EquipmentManager.RarityDisplayName(rarity);
+        string levelText = $"Lv.{Math.Max(1, levelRequirement)}";
+        string playerLevelText = _player == null
+            ? string.Empty
+            : $"  You: Lv.{Math.Max(1L, _player.Level)}";
+        return $"{category} • {rarityName} • Req {levelText}{playerLevelText}";
+    }
+
+    private string BuildEquipmentStats(QuestFantasy.Core.Data.Attributes.Abilities abilities)
+    {
+        if (abilities == null)
+        {
+            return "No stat bonus.";
+        }
+
+        return $"ATK +{abilities.Atk}  DEF +{abilities.Def}\nSPD +{abilities.Spd}  HP +{abilities.Vit}";
     }
 
     private Texture LoadSpriteFromPath(string spritePath)
@@ -1122,7 +1227,15 @@ public class BackpackUI : CanvasLayer
 
         if (_equipButton != null)
         {
-            _equipButton.Disabled = _viewMode != BackpackViewMode.Gear;
+            bool canEquip = false;
+            if (_viewMode == BackpackViewMode.Gear
+                && _selectedGlobalIndex >= 0
+                && _selectedGlobalIndex < _cachedItems.Count)
+            {
+                canEquip = CanEquipItem(_cachedItems[_selectedGlobalIndex], out _);
+            }
+
+            _equipButton.Disabled = !canEquip;
         }
     }
 

--- a/Scripts/UI/ClassSelectUI.cs
+++ b/Scripts/UI/ClassSelectUI.cs
@@ -72,6 +72,7 @@ namespace QuestFantasy.UI
         private readonly Dictionary<string, Label> _statValueLabels = new Dictionary<string, Label>();
         private readonly Dictionary<string, Label> _statAllocationLabels = new Dictionary<string, Label>();
         private readonly Dictionary<string, Button> _statPlusButtons = new Dictionary<string, Button>();
+        private bool _interactionButtonSuppressed = false;
 
         public event Action<PlayerClass> ClassSelected;
         public event Action<List<string>> SkillLoadoutChanged;
@@ -162,6 +163,7 @@ namespace QuestFantasy.UI
             }
             RefreshCardHighlights();
             SwitchTab(0);
+            SetInteractionButtonSuppressed(true);
             _root.Visible = true;
         }
 
@@ -171,6 +173,13 @@ namespace QuestFantasy.UI
             {
                 _root.Visible = false;
             }
+
+            SetInteractionButtonSuppressed(false);
+        }
+
+        public override void _ExitTree()
+        {
+            SetInteractionButtonSuppressed(false);
         }
 
         // ── Layout ────────────────────────────────────────────────────────
@@ -633,6 +642,24 @@ namespace QuestFantasy.UI
             }
 
             return Math.Max(0, _playerLevel - spent);
+        }
+
+        private void SetInteractionButtonSuppressed(bool suppressed)
+        {
+            if (_interactionButtonSuppressed == suppressed)
+            {
+                return;
+            }
+
+            _interactionButtonSuppressed = suppressed;
+            if (suppressed)
+            {
+                InteractionButtonUI.PushSuppression();
+            }
+            else
+            {
+                InteractionButtonUI.PopSuppression();
+            }
         }
 
         // ── Signal handlers ───────────────────────────────────────────────

--- a/Scripts/UI/ClassSelectUI.cs
+++ b/Scripts/UI/ClassSelectUI.cs
@@ -55,16 +55,28 @@ namespace QuestFantasy.UI
         private Label _subtitleLabel;
         private Control _classTabContent;
         private Control _skillTabContent;
+        private Control _statsTabContent;
         private Button _tabClassBtn;
         private Button _tabSkillsBtn;
+        private Button _tabStatsBtn;
         private Panel[] _cardPanels;
 
         // Skill UI References
         private Label[] _skillSlotLabels;
         private Panel[] _skillCardPanels;
 
+        // Stat allocation UI References
+        private Label _availableStatPointsLabel;
+        private readonly Dictionary<string, int> _statValues = new Dictionary<string, int>();
+        private readonly Dictionary<string, int> _statAllocations = new Dictionary<string, int>();
+        private readonly Dictionary<string, Label> _statValueLabels = new Dictionary<string, Label>();
+        private readonly Dictionary<string, Label> _statAllocationLabels = new Dictionary<string, Label>();
+        private readonly Dictionary<string, Button> _statPlusButtons = new Dictionary<string, Button>();
+
         public event Action<PlayerClass> ClassSelected;
         public event Action<List<string>> SkillLoadoutChanged;
+        public delegate bool StatPointRequestHandler(string statKey);
+        public event StatPointRequestHandler StatPointRequested;
 
         private static readonly PlayerClass[] AllClasses =
         {
@@ -106,11 +118,31 @@ namespace QuestFantasy.UI
             _root.Visible = false;
         }
 
-        public void Show(PlayerClass currentClass, int playerLevel, IReadOnlyList<string> currentEquippedSkills = null)
+        public void Show(
+            PlayerClass currentClass,
+            int playerLevel,
+            IReadOnlyList<string> currentEquippedSkills = null,
+            int totalAtk = 0,
+            int totalDef = 0,
+            int totalSpd = 0,
+            int totalHp = 0,
+            int allocatedAtk = 0,
+            int allocatedDef = 0,
+            int allocatedSpd = 0,
+            int allocatedVit = 0)
         {
             _currentClass = currentClass;
             _selectedClass = currentClass;
             _playerLevel = playerLevel;
+            SetStatState(
+                totalAtk,
+                totalDef,
+                totalSpd,
+                totalHp,
+                allocatedAtk,
+                allocatedDef,
+                allocatedSpd,
+                allocatedVit);
 
             _equippedSkillIds.Clear();
             if (currentEquippedSkills != null)
@@ -186,6 +218,11 @@ namespace QuestFantasy.UI
             _tabSkillsBtn.Connect("pressed", this, nameof(OnTabPressed), new Godot.Collections.Array { 1 });
             tabsBox.AddChild(_tabSkillsBtn);
 
+            _tabStatsBtn = CreateStyledButton("📈 Attributes", TabNormal, TabSelected);
+            _tabStatsBtn.SizeFlagsHorizontal = (int)Control.SizeFlags.ExpandFill;
+            _tabStatsBtn.Connect("pressed", this, nameof(OnTabPressed), new Godot.Collections.Array { 2 });
+            tabsBox.AddChild(_tabStatsBtn);
+
             _classTabContent = new Control();
             _classTabContent.SetAnchorsAndMarginsPreset(Control.LayoutPreset.Wide);
             _classTabContent.MarginTop = 50f;
@@ -197,8 +234,15 @@ namespace QuestFantasy.UI
             _skillTabContent.Visible = false;
             panel.AddChild(_skillTabContent);
 
+            _statsTabContent = new Control();
+            _statsTabContent.SetAnchorsAndMarginsPreset(Control.LayoutPreset.Wide);
+            _statsTabContent.MarginTop = 50f;
+            _statsTabContent.Visible = false;
+            panel.AddChild(_statsTabContent);
+
             BuildClassTabContent();
             BuildSkillTabContent();
+            BuildStatsTabContent();
         }
 
         private void BuildClassTabContent()
@@ -312,6 +356,88 @@ namespace QuestFantasy.UI
             saveBtn.RectMinSize = new Vector2(142f, 42f);
             saveBtn.Connect("pressed", this, nameof(OnSaveLoadoutPressed));
             _skillTabContent.AddChild(saveBtn);
+        }
+
+        private void BuildStatsTabContent()
+        {
+            var header = new VBoxContainer();
+            header.SetAnchorsAndMarginsPreset(Control.LayoutPreset.TopWide);
+            header.MarginLeft = 48f;
+            header.MarginRight = -48f;
+            header.MarginTop = 16f;
+            header.MarginBottom = 88f;
+            header.AddConstantOverride("separation", 6);
+            _statsTabContent.AddChild(header);
+
+            _availableStatPointsLabel = MakeLabel("Available Points: 0", 28f, HeaderColor, center: true);
+            header.AddChild(_availableStatPointsLabel);
+
+            var statsPanel = new Panel();
+            statsPanel.SetAnchorsAndMarginsPreset(Control.LayoutPreset.TopWide);
+            statsPanel.MarginLeft = 145f;
+            statsPanel.MarginRight = -145f;
+            statsPanel.MarginTop = 105f;
+            statsPanel.MarginBottom = 360f;
+            statsPanel.AddStyleboxOverride("panel", MakeCardStyle(CardBgNormal, CardBorderNormal));
+            _statsTabContent.AddChild(statsPanel);
+
+            var rowsBox = new VBoxContainer();
+            rowsBox.SetAnchorsAndMarginsPreset(Control.LayoutPreset.Wide);
+            rowsBox.MarginLeft = 18f;
+            rowsBox.MarginRight = -18f;
+            rowsBox.MarginTop = 18f;
+            rowsBox.MarginBottom = -18f;
+            rowsBox.AddConstantOverride("separation", 10);
+            statsPanel.AddChild(rowsBox);
+
+            AddStatAllocationRow(rowsBox, "atk", "ATK", "Damage");
+            AddStatAllocationRow(rowsBox, "def", "DEF", "Defense");
+            AddStatAllocationRow(rowsBox, "spd", "SPD", "Speed");
+            AddStatAllocationRow(rowsBox, "vit", "HP", "Max HP");
+
+            float footerY = PanelHeight - FooterHeight - 50f;
+            var closeBtn = CreateStyledButton("Done", BtnCloseBg, BtnCloseHover);
+            closeBtn.RectPosition = new Vector2(PanelWidth / 2f - 56f, footerY);
+            closeBtn.RectMinSize = new Vector2(112f, 42f);
+            closeBtn.Connect("pressed", this, nameof(OnClosePressed));
+            _statsTabContent.AddChild(closeBtn);
+        }
+
+        private void AddStatAllocationRow(VBoxContainer parent, string statKey, string statName, string statDescription)
+        {
+            var row = new HBoxContainer
+            {
+                RectMinSize = new Vector2(0f, 44f),
+                SizeFlagsHorizontal = (int)Control.SizeFlags.ExpandFill,
+            };
+            row.AddConstantOverride("separation", 12);
+
+            var nameLabel = MakeLabel(statName, 42f, CardTitleColor, center: false);
+            nameLabel.RectMinSize = new Vector2(58f, 42f);
+            row.AddChild(nameLabel);
+
+            var descLabel = MakeLabel(statDescription, 42f, SubHeaderColor, center: false);
+            descLabel.RectMinSize = new Vector2(120f, 42f);
+            row.AddChild(descLabel);
+
+            var valueLabel = MakeLabel("0", 42f, HeaderColor, center: true);
+            valueLabel.RectMinSize = new Vector2(72f, 42f);
+            row.AddChild(valueLabel);
+
+            var allocationLabel = MakeLabel("+0", 42f, SkillLabelColor, center: true);
+            allocationLabel.RectMinSize = new Vector2(62f, 42f);
+            row.AddChild(allocationLabel);
+
+            var plusButton = CreateStyledButton("+", BtnConfirmBg, BtnConfirmHover);
+            plusButton.RectMinSize = new Vector2(44f, 42f);
+            plusButton.Connect("pressed", this, nameof(OnStatPlusPressed), new Godot.Collections.Array { statKey });
+            row.AddChild(plusButton);
+
+            _statValueLabels[statKey] = valueLabel;
+            _statAllocationLabels[statKey] = allocationLabel;
+            _statPlusButtons[statKey] = plusButton;
+
+            parent.AddChild(row);
         }
 
         // ── Card builder ──────────────────────────────────────────────────
@@ -477,19 +603,57 @@ namespace QuestFantasy.UI
             };
         }
 
+        private void SetStatState(
+            int totalAtk,
+            int totalDef,
+            int totalSpd,
+            int totalHp,
+            int allocatedAtk,
+            int allocatedDef,
+            int allocatedSpd,
+            int allocatedVit)
+        {
+            _statValues["atk"] = Math.Max(0, totalAtk);
+            _statValues["def"] = Math.Max(0, totalDef);
+            _statValues["spd"] = Math.Max(0, totalSpd);
+            _statValues["vit"] = Math.Max(0, totalHp);
+
+            _statAllocations["atk"] = Math.Max(0, allocatedAtk);
+            _statAllocations["def"] = Math.Max(0, allocatedDef);
+            _statAllocations["spd"] = Math.Max(0, allocatedSpd);
+            _statAllocations["vit"] = Math.Max(0, allocatedVit);
+        }
+
+        private int GetAvailableStatPoints()
+        {
+            int spent = 0;
+            foreach (int value in _statAllocations.Values)
+            {
+                spent += Math.Max(0, value);
+            }
+
+            return Math.Max(0, _playerLevel - spent);
+        }
+
         // ── Signal handlers ───────────────────────────────────────────────
 
         private void SwitchTab(int tabIndex)
         {
             _classTabContent.Visible = (tabIndex == 0);
             _skillTabContent.Visible = (tabIndex == 1);
+            _statsTabContent.Visible = (tabIndex == 2);
 
             _tabClassBtn.AddStyleboxOverride("normal", MakeButtonStyle(tabIndex == 0 ? TabSelected : TabNormal));
             _tabSkillsBtn.AddStyleboxOverride("normal", MakeButtonStyle(tabIndex == 1 ? TabSelected : TabNormal));
+            _tabStatsBtn.AddStyleboxOverride("normal", MakeButtonStyle(tabIndex == 2 ? TabSelected : TabNormal));
 
             if (tabIndex == 1)
             {
                 RefreshSkillTab();
+            }
+            else if (tabIndex == 2)
+            {
+                RefreshStatsTab();
             }
         }
 
@@ -564,6 +728,34 @@ namespace QuestFantasy.UI
                 }
             }
             RefreshSkillTab();
+        }
+
+        private void OnStatPlusPressed(string statKey)
+        {
+            if (GetAvailableStatPoints() <= 0)
+            {
+                return;
+            }
+
+            bool applied = StatPointRequested?.Invoke(statKey) ?? false;
+            if (!applied)
+            {
+                return;
+            }
+
+            if (!_statValues.ContainsKey(statKey))
+            {
+                _statValues[statKey] = 0;
+            }
+
+            if (!_statAllocations.ContainsKey(statKey))
+            {
+                _statAllocations[statKey] = 0;
+            }
+
+            _statValues[statKey] += statKey == "vit" ? GameConstants.PLAYER_HP_STAT_BONUS : 1;
+            _statAllocations[statKey] += 1;
+            RefreshStatsTab();
         }
 
         // ── Highlight refresh ─────────────────────────────────────────────
@@ -657,6 +849,36 @@ namespace QuestFantasy.UI
 
                     gridBox.AddChild(card);
                     _skillCardPanels[i] = card;
+                }
+            }
+        }
+
+        private void RefreshStatsTab()
+        {
+            int availablePoints = GetAvailableStatPoints();
+            if (_availableStatPointsLabel != null)
+            {
+                _availableStatPointsLabel.Text = $"Available Points: {availablePoints}";
+            }
+
+            foreach (string statKey in new[] { "atk", "def", "spd", "vit" })
+            {
+                int totalValue = _statValues.ContainsKey(statKey) ? _statValues[statKey] : 0;
+                int allocatedValue = _statAllocations.ContainsKey(statKey) ? _statAllocations[statKey] : 0;
+
+                if (_statValueLabels.ContainsKey(statKey))
+                {
+                    _statValueLabels[statKey].Text = totalValue.ToString();
+                }
+
+                if (_statAllocationLabels.ContainsKey(statKey))
+                {
+                    _statAllocationLabels[statKey].Text = $"+{allocatedValue}";
+                }
+
+                if (_statPlusButtons.ContainsKey(statKey))
+                {
+                    _statPlusButtons[statKey].Disabled = availablePoints <= 0;
                 }
             }
         }

--- a/Scripts/UI/ClassSelectUI.cs
+++ b/Scripts/UI/ClassSelectUI.cs
@@ -72,12 +72,14 @@ namespace QuestFantasy.UI
         private readonly Dictionary<string, Label> _statValueLabels = new Dictionary<string, Label>();
         private readonly Dictionary<string, Label> _statAllocationLabels = new Dictionary<string, Label>();
         private readonly Dictionary<string, Button> _statPlusButtons = new Dictionary<string, Button>();
+        private Button _statResetButton;
         private bool _interactionButtonSuppressed = false;
 
         public event Action<PlayerClass> ClassSelected;
         public event Action<List<string>> SkillLoadoutChanged;
         public delegate bool StatPointRequestHandler(string statKey);
         public event StatPointRequestHandler StatPointRequested;
+        public event Func<bool> StatPointsResetRequested;
 
         private static readonly PlayerClass[] AllClasses =
         {
@@ -405,8 +407,14 @@ namespace QuestFantasy.UI
             AddStatAllocationRow(rowsBox, "vit", "HP", "Max HP");
 
             float footerY = PanelHeight - FooterHeight - 50f;
+            _statResetButton = CreateStyledButton("Reset", BtnCloseBg, BtnCloseHover);
+            _statResetButton.RectPosition = new Vector2(PanelWidth / 2f - 120f, footerY);
+            _statResetButton.RectMinSize = new Vector2(112f, 42f);
+            _statResetButton.Connect("pressed", this, nameof(OnResetStatsPressed));
+            _statsTabContent.AddChild(_statResetButton);
+
             var closeBtn = CreateStyledButton("Done", BtnCloseBg, BtnCloseHover);
-            closeBtn.RectPosition = new Vector2(PanelWidth / 2f - 56f, footerY);
+            closeBtn.RectPosition = new Vector2(PanelWidth / 2f + 8f, footerY);
             closeBtn.RectMinSize = new Vector2(112f, 42f);
             closeBtn.Connect("pressed", this, nameof(OnClosePressed));
             _statsTabContent.AddChild(closeBtn);
@@ -635,13 +643,18 @@ namespace QuestFantasy.UI
 
         private int GetAvailableStatPoints()
         {
+            return Math.Max(0, _playerLevel - GetSpentStatPoints());
+        }
+
+        private int GetSpentStatPoints()
+        {
             int spent = 0;
             foreach (int value in _statAllocations.Values)
             {
                 spent += Math.Max(0, value);
             }
 
-            return Math.Max(0, _playerLevel - spent);
+            return Math.Max(0, spent);
         }
 
         private void SetInteractionButtonSuppressed(bool suppressed)
@@ -785,6 +798,34 @@ namespace QuestFantasy.UI
             RefreshStatsTab();
         }
 
+        private void OnResetStatsPressed()
+        {
+            if (GetSpentStatPoints() <= 0)
+            {
+                return;
+            }
+
+            bool reset = StatPointsResetRequested?.Invoke() ?? false;
+            if (!reset)
+            {
+                return;
+            }
+
+            foreach (string statKey in new[] { "atk", "def", "spd", "vit" })
+            {
+                int allocatedValue = _statAllocations.ContainsKey(statKey) ? _statAllocations[statKey] : 0;
+                int totalValue = _statValues.ContainsKey(statKey) ? _statValues[statKey] : 0;
+                int statBonus = statKey == "vit"
+                    ? allocatedValue * GameConstants.PLAYER_HP_STAT_BONUS
+                    : allocatedValue;
+
+                _statValues[statKey] = Math.Max(0, totalValue - statBonus);
+                _statAllocations[statKey] = 0;
+            }
+
+            RefreshStatsTab();
+        }
+
         // ── Highlight refresh ─────────────────────────────────────────────
 
         private void RefreshCardHighlights()
@@ -907,6 +948,11 @@ namespace QuestFantasy.UI
                 {
                     _statPlusButtons[statKey].Disabled = availablePoints <= 0;
                 }
+            }
+
+            if (_statResetButton != null)
+            {
+                _statResetButton.Disabled = GetSpentStatPoints() <= 0;
             }
         }
 

--- a/Scripts/UI/DeathScreenUI.cs
+++ b/Scripts/UI/DeathScreenUI.cs
@@ -2,12 +2,15 @@ using System;
 
 using Godot;
 
+using QuestFantasy.UI;
+
 public class DeathScreenUI : CanvasLayer
 {
     public event Action OnRespawnClicked;
     public event Action OnExitClicked;
 
     private Control _root;
+    private bool _interactionButtonSuppressed = false;
 
     public override void _Ready()
     {
@@ -20,6 +23,31 @@ public class DeathScreenUI : CanvasLayer
         if (_root != null)
         {
             _root.Visible = visible;
+        }
+
+        SetInteractionButtonSuppressed(visible);
+    }
+
+    public override void _ExitTree()
+    {
+        SetInteractionButtonSuppressed(false);
+    }
+
+    private void SetInteractionButtonSuppressed(bool suppressed)
+    {
+        if (_interactionButtonSuppressed == suppressed)
+        {
+            return;
+        }
+
+        _interactionButtonSuppressed = suppressed;
+        if (suppressed)
+        {
+            InteractionButtonUI.PushSuppression();
+        }
+        else
+        {
+            InteractionButtonUI.PopSuppression();
         }
     }
 

--- a/Scripts/UI/DifficultySelectionUI.cs
+++ b/Scripts/UI/DifficultySelectionUI.cs
@@ -5,6 +5,7 @@ using Godot;
 
 using QuestFantasy.Characters;
 using QuestFantasy.Core.Data.Items;
+using QuestFantasy.UI;
 
 /// <summary>
 /// UI for difficulty selection when entering a game level from the lobby.
@@ -17,6 +18,7 @@ public class DifficultySelectionUI : CanvasLayer
     private Control _uiContainer;
     private VBoxContainer _buttonContainer;
     private bool _isVisible;
+    private bool _interactionButtonSuppressed = false;
     private Player _player;
     private readonly Dictionary<DifficultyLevel, Button> _difficultyButtons = new Dictionary<DifficultyLevel, Button>();
 
@@ -133,6 +135,7 @@ public class DifficultySelectionUI : CanvasLayer
     public void ShowDifficultyMenu()
     {
         RefreshLocks();
+        SetInteractionButtonSuppressed(true);
         _uiContainer.Visible = true;
         _isVisible = true;
         GetTree().Paused = true;
@@ -142,7 +145,31 @@ public class DifficultySelectionUI : CanvasLayer
     {
         _uiContainer.Visible = false;
         _isVisible = false;
+        SetInteractionButtonSuppressed(false);
         GetTree().Paused = false;
+    }
+
+    public override void _ExitTree()
+    {
+        SetInteractionButtonSuppressed(false);
+    }
+
+    private void SetInteractionButtonSuppressed(bool suppressed)
+    {
+        if (_interactionButtonSuppressed == suppressed)
+        {
+            return;
+        }
+
+        _interactionButtonSuppressed = suppressed;
+        if (suppressed)
+        {
+            InteractionButtonUI.PushSuppression();
+        }
+        else
+        {
+            InteractionButtonUI.PopSuppression();
+        }
     }
 
     public bool IsMenuVisible => _isVisible;

--- a/Scripts/UI/EquipmentPreview.cs
+++ b/Scripts/UI/EquipmentPreview.cs
@@ -18,6 +18,10 @@ public class EquipmentPreview : CanvasLayer
     public int HeaderTopPadding = 8;
     [Export]
     public int InnerHorizontalPadding = 12;
+    [Export]
+    public int ScreenMargin = 24;
+    [Export]
+    public int ShadowOffset = 4;
 
     public override void _Ready()
     {
@@ -59,6 +63,7 @@ public class EquipmentPreview : CanvasLayer
 
         // Shadow panel (slightly offset to simulate drop shadow)
         _shadowPanel = new Panel();
+        _shadowPanel.MouseFilter = Control.MouseFilterEnum.Ignore;
         var shadowStyle = new StyleBoxFlat();
         shadowStyle.BgColor = new Color(0, 0, 0, 0.25f);
         shadowStyle.CornerRadiusTopLeft = 8;
@@ -70,16 +75,19 @@ public class EquipmentPreview : CanvasLayer
         AddChild(_shadowPanel);
 
         _panel = new Panel();
+        _panel.MouseFilter = Control.MouseFilterEnum.Ignore;
         _panel.Visible = false;
         AddChild(_panel);
 
         _box = new VBoxContainer();
+        _box.MouseFilter = Control.MouseFilterEnum.Ignore;
         _box.RectMinSize = new Vector2(200, 10);
 
         // Panel background will be drawn by the Panel's StyleBoxFlat (rounded corners)
 
         // Inner panel to provide padding and border for attributes
         var innerPanel = new Panel();
+        innerPanel.MouseFilter = Control.MouseFilterEnum.Ignore;
         var innerStyle = new StyleBoxFlat();
         innerStyle.BorderColor = new Color(0.2f, 0.2f, 0.2f);
         innerStyle.BorderWidthLeft = 1;
@@ -98,9 +106,12 @@ public class EquipmentPreview : CanvasLayer
         innerPanel.AddStyleboxOverride("panel", innerStyle);
         // Wrap the VBox in a horizontal container with left/right spacers
         var wrapper = new HBoxContainer();
+        wrapper.MouseFilter = Control.MouseFilterEnum.Ignore;
         var leftSpacer = new Control();
+        leftSpacer.MouseFilter = Control.MouseFilterEnum.Ignore;
         leftSpacer.RectMinSize = new Vector2(InnerHorizontalPadding, 0);
         var rightSpacer = new Control();
+        rightSpacer.MouseFilter = Control.MouseFilterEnum.Ignore;
         rightSpacer.RectMinSize = new Vector2(InnerHorizontalPadding, 0);
         wrapper.AddChild(leftSpacer);
         wrapper.AddChild(_box);
@@ -138,10 +149,12 @@ public class EquipmentPreview : CanvasLayer
         }
         // Add explicit top spacer so there's visible space above the first line
         var topSpacer = new Control();
+        topSpacer.MouseFilter = Control.MouseFilterEnum.Ignore;
         topSpacer.RectMinSize = new Vector2(0, InnerTopPadding);
         _box.AddChild(topSpacer);
         // Header: icon + title + rarity
         var header = new HBoxContainer();
+        header.MouseFilter = Control.MouseFilterEnum.Ignore;
         var headerStyle = new StyleBoxFlat();
         headerStyle.BgColor = new Color(0, 0, 0, 0.0f);
         headerStyle.ContentMarginLeft = 4;
@@ -162,7 +175,7 @@ public class EquipmentPreview : CanvasLayer
         if (item is QuestFantasy.Core.Data.Items.Equipment eq)
         {
             titleText = eq.Name ?? eq.EquipmentType.ToString();
-            metaText = $"{eq.EquipmentType} • Rarity {eq.Rarity}";
+            metaText = $"{eq.EquipmentType} • {EquipmentManager.RarityDisplayName(eq.Rarity)} • Lv.{Math.Max(1, eq.LevelRequirement)}";
             rarityColor = GetRarityColor(eq.Rarity);
             if (!string.IsNullOrEmpty(eq.SpritePath))
             {
@@ -174,7 +187,7 @@ public class EquipmentPreview : CanvasLayer
         else if (item is QuestFantasy.Core.Data.Items.Weapon w)
         {
             titleText = w.Name ?? w.WeaponType.ToString();
-            metaText = $"{w.WeaponType} • Rarity {w.Rarity}";
+            metaText = $"{w.WeaponType} • {EquipmentManager.RarityDisplayName(w.Rarity)} • Lv.{Math.Max(1, w.LevelRequirement)}";
             rarityColor = GetRarityColor(w.Rarity);
             if (!string.IsNullOrEmpty(w.SpritePath))
             {
@@ -213,6 +226,7 @@ public class EquipmentPreview : CanvasLayer
 
         // Icon
         var iconRect = new TextureRect();
+        iconRect.MouseFilter = Control.MouseFilterEnum.Ignore;
         iconRect.RectMinSize = new Vector2(48, 48);
         iconRect.Expand = true;
         iconRect.StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered;
@@ -221,7 +235,9 @@ public class EquipmentPreview : CanvasLayer
 
         // Title + meta
         var titleBox = new VBoxContainer();
+        titleBox.MouseFilter = Control.MouseFilterEnum.Ignore;
         var title = new Label();
+        title.MouseFilter = Control.MouseFilterEnum.Ignore;
         title.Text = titleText;
         title.AddColorOverride("font_color", new Color(0.95f, 0.95f, 0.95f));
         title.AddColorOverride("font_color_shadow", new Color(0, 0, 0, 0.5f));
@@ -229,6 +245,7 @@ public class EquipmentPreview : CanvasLayer
         titleBox.AddChild(title);
 
         var meta = new Label();
+        meta.MouseFilter = Control.MouseFilterEnum.Ignore;
         meta.Text = metaText;
         meta.AddColorOverride("font_color", rarityColor);
         titleBox.AddChild(meta);
@@ -247,62 +264,82 @@ public class EquipmentPreview : CanvasLayer
         float height = FixedPreviewHeight;
         _panel.RectSize = new Vector2(width, height);
 
-        // Convert world position to screen coordinates using active Camera2D if available.
-        Vector2 screenPos = globalPos;
         var vp = GetViewport();
-        if (vp != null)
-        {
-            var cam = FindActiveCamera2D();
-            if (cam != null)
-            {
-                screenPos = globalPos - cam.GlobalPosition + vp.Size * 0.5f;
-            }
-        }
+        var pos = GetTopRightScreenPosition(vp);
 
-        // clamp within viewport
-        var pos = screenPos + new Vector2(16, 16);
-        var maxX = vp.Size.x - _panel.RectSize.x - 8;
-        var maxY = vp.Size.y - _panel.RectSize.y - 8;
-        pos.x = Math.Min(Math.Max(8, pos.x), Math.Max(8, maxX));
-        pos.y = Math.Min(Math.Max(8, pos.y), Math.Max(8, maxY));
         // position shadow slightly offset and sized the same
         if (_shadowPanel != null)
         {
             _shadowPanel.RectSize = _panel.RectSize;
-            _shadowPanel.RectPosition = pos + new Vector2(4, 4);
+            _shadowPanel.RectPosition = pos + new Vector2(ShadowOffset, ShadowOffset);
             _shadowPanel.Visible = true;
         }
         _panel.RectPosition = pos;
+        SetMouseIgnoreRecursive(_panel);
         _panel.Visible = true;
+    }
+
+    private void SetMouseIgnoreRecursive(Control control)
+    {
+        if (control == null)
+        {
+            return;
+        }
+
+        control.MouseFilter = Control.MouseFilterEnum.Ignore;
+        foreach (Node child in control.GetChildren())
+        {
+            if (child is Control childControl)
+            {
+                SetMouseIgnoreRecursive(childControl);
+            }
+        }
+    }
+
+    private Vector2 GetTopRightScreenPosition(Viewport viewport)
+    {
+        var viewportSize = viewport?.Size ?? OS.WindowSize;
+        float margin = Math.Max(0, ScreenMargin);
+        float shadowOffset = Math.Max(0, ShadowOffset);
+
+        float maxX = viewportSize.x - _panel.RectSize.x - margin - shadowOffset;
+        float maxY = viewportSize.y - _panel.RectSize.y - margin - shadowOffset;
+        float x = Math.Max(margin, maxX);
+        float y = Math.Min(margin, Math.Max(margin, maxY));
+
+        return new Vector2(x, y);
     }
 
     private void AddAttributeGrid(int atk, int def, int spd, int vit, int levelReq, int price)
     {
         var grid = new GridContainer();
+        grid.MouseFilter = Control.MouseFilterEnum.Ignore;
         grid.Columns = 2;
-        grid.AddChild(new Label() { Text = $"Attack: +{atk}" });
-        grid.AddChild(new Label() { Text = $"Defense: +{def}" });
-        grid.AddChild(new Label() { Text = $"Agility: +{spd}" });
-        grid.AddChild(new Label() { Text = $"HP: +{vit}" });
-        grid.AddChild(new Label() { Text = $"Level Req:" });
-        grid.AddChild(new Label() { Text = $"{levelReq}" });
+        grid.AddChild(MakePreviewLabel($"Attack: +{atk}"));
+        grid.AddChild(MakePreviewLabel($"Defense: +{def}"));
+        grid.AddChild(MakePreviewLabel($"Agility: +{spd}"));
+        grid.AddChild(MakePreviewLabel($"HP: +{vit}"));
+        grid.AddChild(MakePreviewLabel("Level Req:"));
+        grid.AddChild(MakePreviewLabel($"{levelReq}"));
         var priceLabel = new Label() { Text = $"Price: {price}" };
+        priceLabel.MouseFilter = Control.MouseFilterEnum.Ignore;
         priceLabel.AddColorOverride("font_color", new Color(0.95f, 0.9f, 0.6f));
         grid.AddChild(priceLabel);
         _box.AddChild(grid);
     }
 
+    private Label MakePreviewLabel(string text)
+    {
+        return new Label
+        {
+            Text = text,
+            MouseFilter = Control.MouseFilterEnum.Ignore,
+        };
+    }
+
     private Color GetRarityColor(int rarity)
     {
-        switch (rarity)
-        {
-            case 0: return new Color(0.8f, 0.8f, 0.8f); // common
-            case 1: return new Color(0.3f, 0.8f, 0.3f); // uncommon
-            case 2: return new Color(0.2f, 0.6f, 1.0f); // rare
-            case 3: return new Color(0.7f, 0.3f, 1.0f); // epic
-            case 4: return new Color(1.0f, 0.75f, 0.2f); // legendary
-            default: return new Color(0.9f, 0.9f, 0.9f);
-        }
+        return EquipmentManager.RarityColor(rarity);
     }
 
     public void Show(object item, Vector2 globalPos)

--- a/Scripts/UI/EquipmentPreview.cs
+++ b/Scripts/UI/EquipmentPreview.cs
@@ -283,7 +283,7 @@ public class EquipmentPreview : CanvasLayer
         grid.AddChild(new Label() { Text = $"Attack: +{atk}" });
         grid.AddChild(new Label() { Text = $"Defense: +{def}" });
         grid.AddChild(new Label() { Text = $"Agility: +{spd}" });
-        grid.AddChild(new Label() { Text = $"Stamina: +{vit}" });
+        grid.AddChild(new Label() { Text = $"HP: +{vit}" });
         grid.AddChild(new Label() { Text = $"Level Req:" });
         grid.AddChild(new Label() { Text = $"{levelReq}" });
         var priceLabel = new Label() { Text = $"Price: {price}" };

--- a/Scripts/UI/InteractionButtonUI.cs
+++ b/Scripts/UI/InteractionButtonUI.cs
@@ -24,11 +24,14 @@ namespace QuestFantasy.UI
         /// </summary>
         public static bool IsButtonVisible { get; private set; }
 
+        public static bool IsSuppressed => _suppressRequestCount > 0;
+
         private const float ButtonWidth = 110f;
         private const float ButtonHeight = 48f;
         private const float OffsetY = -40f; // Above the object
         private const float ScreenPadding = 8f;
 
+        private static int _suppressRequestCount = 0;
         private Button _button;
         private bool _pressed;
         private Vector2 _worldTarget = Vector2.Zero;
@@ -131,6 +134,12 @@ namespace QuestFantasy.UI
         /// </summary>
         public void Show(string label, Vector2 worldPosition)
         {
+            if (IsSuppressed)
+            {
+                HideButton();
+                return;
+            }
+
             _button.Text = label;
             _worldTarget = worldPosition;
             _tracking = true;
@@ -155,13 +164,33 @@ namespace QuestFantasy.UI
             IsButtonVisible = false;
         }
 
+        public static void PushSuppression()
+        {
+            _suppressRequestCount++;
+            WasJustPressed = false;
+            Instance?.HideButton();
+        }
+
+        public static void PopSuppression()
+        {
+            if (_suppressRequestCount > 0)
+            {
+                _suppressRequestCount--;
+            }
+
+            if (IsSuppressed)
+            {
+                Instance?.HideButton();
+            }
+        }
+
         /// <summary>
         /// Check if the button was pressed this frame. Does not consume the press,
         /// allowing multiple scripts to react (matching keyboard 'F' behavior).
         /// </summary>
         public static bool IsPressed()
         {
-            return WasJustPressed;
+            return !IsSuppressed && WasJustPressed;
         }
 
         private void OnButtonPressed()
@@ -202,6 +231,7 @@ namespace QuestFantasy.UI
                 Instance = null;
                 IsButtonVisible = false;
                 WasJustPressed = false;
+                _suppressRequestCount = 0;
             }
         }
     }

--- a/Scripts/UI/MarketplaceUI.cs
+++ b/Scripts/UI/MarketplaceUI.cs
@@ -5,6 +5,7 @@ using Godot;
 
 using QuestFantasy.Characters;
 using QuestFantasy.Core.Data.Items;
+using QuestFantasy.UI;
 
 /// <summary>
 /// Player-to-player marketplace UI.
@@ -26,6 +27,7 @@ public class MarketplaceUI : CanvasLayer
     private PanelContainer _panel;
     private Label _titleLabel;
     private Label _goldLabel;
+    private bool _interactionButtonSuppressed = false;
     private Label _statusLabel;
     private TabContainer _tabs;
     private bool _isVisible;
@@ -82,6 +84,7 @@ public class MarketplaceUI : CanvasLayer
 
     public new void Show()
     {
+        SetInteractionButtonSuppressed(true);
         _isVisible = true;
         _root.Visible = true;
         _panel.Visible = true;
@@ -102,7 +105,31 @@ public class MarketplaceUI : CanvasLayer
         }
         if (_root != null) _root.Visible = false;
         if (_panel != null) _panel.Visible = false;
+        SetInteractionButtonSuppressed(false);
         GetTree().Paused = false;
+    }
+
+    public override void _ExitTree()
+    {
+        SetInteractionButtonSuppressed(false);
+    }
+
+    private void SetInteractionButtonSuppressed(bool suppressed)
+    {
+        if (_interactionButtonSuppressed == suppressed)
+        {
+            return;
+        }
+
+        _interactionButtonSuppressed = suppressed;
+        if (suppressed)
+        {
+            InteractionButtonUI.PushSuppression();
+        }
+        else
+        {
+            InteractionButtonUI.PopSuppression();
+        }
     }
 
     public override void _Process(float delta)

--- a/Scripts/UI/NpcShopUI.cs
+++ b/Scripts/UI/NpcShopUI.cs
@@ -672,22 +672,7 @@ public class NpcShopUI : CanvasLayer
 
     private Color GetRarityColor(Item item)
     {
-        int rarity = GetItemRarity(item);
-        switch (rarity)
-        {
-            case 0:
-                return new Color(0.72f, 0.72f, 0.72f);
-            case 1:
-                return new Color(0.34f, 0.80f, 0.34f);
-            case 2:
-                return new Color(0.23f, 0.60f, 1.0f);
-            case 3:
-                return new Color(0.75f, 0.38f, 1.0f);
-            case 4:
-                return new Color(1.0f, 0.78f, 0.24f);
-            default:
-                return new Color(0.95f, 0.95f, 0.95f);
-        }
+        return EquipmentManager.RarityColor(GetItemRarity(item));
     }
 
     private int GetItemRarity(Item item)
@@ -954,18 +939,19 @@ public class NpcShopUI : CanvasLayer
     private string BuildPreviewMeta(Item item)
     {
         int rarity = GetItemRarity(item);
+        string rarityName = EquipmentManager.RarityDisplayName(rarity);
 
         if (item is Equipment equipment)
         {
-            return $"{equipment.EquipmentType}  •  Rarity {rarity}";
+            return $"{equipment.EquipmentType}  •  {rarityName}  •  Lv.{Math.Max(1, equipment.LevelRequirement)}";
         }
 
         if (item is Weapon weapon)
         {
-            return $"{weapon.WeaponType}  •  Rarity {rarity}";
+            return $"{weapon.WeaponType}  •  {rarityName}  •  Lv.{Math.Max(1, weapon.LevelRequirement)}";
         }
 
-        return $"Rarity {rarity}";
+        return rarity > 0 ? rarityName : "Common";
     }
 
     private string BuildPreviewStats(Item item)

--- a/Scripts/UI/NpcShopUI.cs
+++ b/Scripts/UI/NpcShopUI.cs
@@ -5,6 +5,7 @@ using Godot;
 
 using QuestFantasy.Characters;
 using QuestFantasy.Core.Data.Items;
+using QuestFantasy.UI;
 
 /// <summary>
 /// Minimal shop UI used by lobby NPCs.
@@ -183,6 +184,7 @@ public class NpcShopUI : CanvasLayer
     private NPC _activeNpc;
     private Player _activePlayer;
     private bool _isVisible;
+    private bool _interactionButtonSuppressed = false;
 
     public override void _Ready()
     {
@@ -217,6 +219,7 @@ public class NpcShopUI : CanvasLayer
 
         RebuildLists();
 
+        SetInteractionButtonSuppressed(true);
         _root.Visible = true;
         _panel.Visible = true;
         _isVisible = true;
@@ -241,7 +244,31 @@ public class NpcShopUI : CanvasLayer
         _activeNpc = null;
         _activePlayer = null;
         _isVisible = false;
+        SetInteractionButtonSuppressed(false);
         GetTree().Paused = false;
+    }
+
+    public override void _ExitTree()
+    {
+        SetInteractionButtonSuppressed(false);
+    }
+
+    private void SetInteractionButtonSuppressed(bool suppressed)
+    {
+        if (_interactionButtonSuppressed == suppressed)
+        {
+            return;
+        }
+
+        _interactionButtonSuppressed = suppressed;
+        if (suppressed)
+        {
+            InteractionButtonUI.PushSuppression();
+        }
+        else
+        {
+            InteractionButtonUI.PopSuppression();
+        }
     }
 
     public override void _Process(float delta)

--- a/Scripts/UI/NpcShopUI.cs
+++ b/Scripts/UI/NpcShopUI.cs
@@ -14,6 +14,8 @@ using QuestFantasy.UI;
 public class NpcShopUI : CanvasLayer
 {
     public event Action Closed;
+    public event Func<NPC, Player, int> RefreshCostRequested;
+    public event Func<NPC, Player, bool> RefreshRequested;
 
     private sealed class ShopItemSlot : PanelContainer
     {
@@ -180,6 +182,7 @@ public class NpcShopUI : CanvasLayer
     private ShopItemSlot _selectedSellSlot;
     private Item _previewedItem;
     private Button _closeButton;
+    private Button _refreshStockButton;
 
     private NPC _activeNpc;
     private Player _activePlayer;
@@ -217,6 +220,7 @@ public class NpcShopUI : CanvasLayer
             _statusLabel.Text = GetShopStatusText();
         }
 
+        UpdateRefreshButton();
         RebuildLists();
 
         SetInteractionButtonSuppressed(true);
@@ -377,6 +381,15 @@ public class NpcShopUI : CanvasLayer
             Align = Label.AlignEnum.Center
         };
         column.AddChild(titleLabel);
+
+        _refreshStockButton = new Button
+        {
+            Text = "Refresh Stock",
+            RectMinSize = new Vector2(0f, 32f),
+            Visible = false
+        };
+        _refreshStockButton.Connect("pressed", this, nameof(OnRefreshStockPressed));
+        column.AddChild(_refreshStockButton);
 
         scrollContainer = new ScrollContainer
         {
@@ -563,7 +576,39 @@ public class NpcShopUI : CanvasLayer
             return $"{_activeNpc.EntityName} has no items in stock yet. {goldText}";
         }
 
-        return $"Buy basic equipment from {_activeNpc.EntityName}. {goldText}";
+        return $"Buy level-scaled equipment from {_activeNpc.EntityName}. {goldText}";
+    }
+
+    private int GetActiveRefreshCost()
+    {
+        if (_activeNpc == null || _activePlayer == null)
+        {
+            return 0;
+        }
+
+        return Math.Max(0, RefreshCostRequested?.Invoke(_activeNpc, _activePlayer) ?? 0);
+    }
+
+    private void UpdateRefreshButton()
+    {
+        if (_refreshStockButton == null)
+        {
+            return;
+        }
+
+        bool canRefresh = _activeNpc != null
+            && _activeNpc.Role == NpcRole.Blacksmith
+            && RefreshRequested != null;
+
+        _refreshStockButton.Visible = canRefresh;
+        if (!canRefresh)
+        {
+            return;
+        }
+
+        int cost = GetActiveRefreshCost();
+        _refreshStockButton.Text = $"Refresh Stock ({cost}g)";
+        _refreshStockButton.Disabled = _activePlayer == null || _activePlayer.Gold < cost;
     }
 
     private void RebuildBuyList()
@@ -573,6 +618,7 @@ public class NpcShopUI : CanvasLayer
             return;
         }
 
+        UpdateRefreshButton();
         ClearBuySelection();
         ClearContainer(_buyGridContainer);
 
@@ -813,6 +859,7 @@ public class NpcShopUI : CanvasLayer
             ClearBuySelection();
             ResetPreviewPanel();
             RebuildLists();
+            UpdateRefreshButton();
             return;
         }
 
@@ -889,6 +936,7 @@ public class NpcShopUI : CanvasLayer
             ClearSellSelection();
             ResetPreviewPanel();
             RebuildLists();
+            UpdateRefreshButton();
             return;
         }
 
@@ -903,6 +951,37 @@ public class NpcShopUI : CanvasLayer
         if (_selectedBuySlot != null)
         {
             OnBuySlotActivated(_selectedBuySlot);
+        }
+    }
+
+    private void OnRefreshStockPressed()
+    {
+        if (_activeNpc == null || _activePlayer == null || RefreshRequested == null)
+        {
+            return;
+        }
+
+        int cost = GetActiveRefreshCost();
+        bool refreshed = RefreshRequested.Invoke(_activeNpc, _activePlayer);
+        if (!refreshed)
+        {
+            if (_statusLabel != null)
+            {
+                _statusLabel.Text = $"Could not refresh stock. Need {cost} gold.";
+            }
+
+            UpdateRefreshButton();
+            return;
+        }
+
+        ClearBuySelection();
+        ResetPreviewPanel();
+        RebuildLists();
+        UpdateRefreshButton();
+
+        if (_statusLabel != null)
+        {
+            _statusLabel.Text = $"Stock refreshed for {cost} gold. You have {_activePlayer.Gold} gold.";
         }
     }
 
@@ -1017,6 +1096,16 @@ public class NpcShopUI : CanvasLayer
         if (item == null || item.Price <= 0)
         {
             return 0;
+        }
+
+        if (item is Equipment equipment)
+        {
+            return EquipmentManager.GetShopPriceByRarity(equipment.Rarity, equipment.LevelRequirement);
+        }
+
+        if (item is Weapon weapon)
+        {
+            return EquipmentManager.GetShopPriceByRarity(weapon.Rarity, weapon.LevelRequirement);
         }
 
         return Math.Max(1, item.Price / 2);

--- a/Scripts/UI/NpcShopUI.cs
+++ b/Scripts/UI/NpcShopUI.cs
@@ -945,12 +945,12 @@ public class NpcShopUI : CanvasLayer
     {
         if (item is Equipment equipment)
         {
-            return $"ATK +{equipment.EquipmentAbilities?.Atk ?? 0}\nDEF +{equipment.EquipmentAbilities?.Def ?? 0}\nSPD +{equipment.EquipmentAbilities?.Spd ?? 0}\nVIT +{equipment.EquipmentAbilities?.Vit ?? 0}\nLevel Req {equipment.LevelRequirement}";
+            return $"ATK +{equipment.EquipmentAbilities?.Atk ?? 0}\nDEF +{equipment.EquipmentAbilities?.Def ?? 0}\nSPD +{equipment.EquipmentAbilities?.Spd ?? 0}\nHP +{equipment.EquipmentAbilities?.Vit ?? 0}\nLevel Req {equipment.LevelRequirement}";
         }
 
         if (item is Weapon weapon)
         {
-            return $"ATK +{weapon.WeaponAbilities?.Atk ?? 0}\nDEF +{weapon.WeaponAbilities?.Def ?? 0}\nSPD +{weapon.WeaponAbilities?.Spd ?? 0}\nVIT +{weapon.WeaponAbilities?.Vit ?? 0}\nLevel Req {weapon.LevelRequirement}";
+            return $"ATK +{weapon.WeaponAbilities?.Atk ?? 0}\nDEF +{weapon.WeaponAbilities?.Def ?? 0}\nSPD +{weapon.WeaponAbilities?.Spd ?? 0}\nHP +{weapon.WeaponAbilities?.Vit ?? 0}\nLevel Req {weapon.LevelRequirement}";
         }
 
         return "No extra stats.";


### PR DESCRIPTION
重點修改：
1. 裝備稀有度：新增 5 種稀有度，影響裝備數值與顯示顏色。
2. 裝備等級：裝備會依玩家等級生成，數值隨等級線性成長。
3. 商店系統：Blacksmith 商品依玩家等級產生，稀有裝也會出現。
4. 商店刷新：商品不會自動刷新，玩家要花金幣手動刷新。
5. 角色平衡：不同職業有不同基礎 ATK / DEF / SPD / HP。
6. 職業武器加成：Archer 用弓、Knight 用劍、Mage 用法杖時，武器效果 1.5 倍。

小調整：
1. 擊殺怪物一次最多掉一個物品。
2. 怪物掉物品機率改成 50%。
3. 金幣掉落重新平衡，避免太少或太誇張。
4. 商店買賣價格改成依「稀有度 + 裝備等級」計算。
5. SPD 對移動速度的影響降低，避免高等跑太快。
6. FireMonster / SpeedMonster 數值跟普通怪做區分。

Bug 修復：
1. 大廳中不能再施放技能。
2. 職業基礎數值現在會正確套用。
3. SPD 現在會實際影響玩家移動。
4. 玩家 DEF 現在會減少怪物攻擊傷害。
