### PR TITLE
feat: implement server-side treasure chest loot generation and secure…

### DIFF
--- a/Scripts/Auth/AuthApiClient.cs
+++ b/Scripts/Auth/AuthApiClient.cs
@@ -248,7 +248,9 @@ public class AuthApiClient : Node
         FetchMarketplaceListings,
         CreateMarketplaceListing,
         CancelMarketplaceListing,
-        BuyMarketplaceListing
+        BuyMarketplaceListing,
+        GenerateDrops,
+        ClearDrops
     }
 
     [Export] public string BackendBaseUrl = BackendDefaults.BackendBaseUrl;
@@ -450,6 +452,39 @@ public class AuthApiClient : Node
             callback);
     }
 
+    public bool GenerateDrops(string token, int playerLevel, string dropSource, string difficulty, Action<AuthApiResult> callback)
+    {
+        var payload = new Godot.Collections.Dictionary
+        {
+            ["action"] = "generate",
+            ["player_level"] = playerLevel,
+            ["drop_source"] = dropSource,
+            ["difficulty"] = difficulty
+        };
+        return SendRequest(
+            AuthRequestKind.GenerateDrops,
+            "/api/player/drop/",
+            HTTPClient.Method.Post,
+            payload,
+            token,
+            callback);
+    }
+
+    public bool ClearDrops(string token, Action<AuthApiResult> callback)
+    {
+        var payload = new Godot.Collections.Dictionary
+        {
+            ["action"] = "clear"
+        };
+        return SendRequest(
+            AuthRequestKind.ClearDrops,
+            "/api/player/drop/",
+            HTTPClient.Method.Post,
+            payload,
+            token,
+            callback);
+    }
+
     private bool SendRequest(
         AuthRequestKind kind,
         string endpointPath,
@@ -600,6 +635,41 @@ public class AuthApiClient : Node
                         result.Data[key] = payload[key];
                     }
                 }
+                break;
+
+            case AuthRequestKind.GenerateDrops:
+                result.ArrayData = new Godot.Collections.Array();
+                // Mock Gold Drop
+                result.ArrayData.Add(new Godot.Collections.Dictionary
+                {
+                    ["instance_id"] = Guid.NewGuid().ToString("N"),
+                    ["item_type"] = "gold",
+                    ["gold_amount"] = 35,
+                    ["item_data"] = null
+                });
+                // Mock Item Drop (Hp Potion S)
+                result.ArrayData.Add(new Godot.Collections.Dictionary
+                {
+                    ["instance_id"] = Guid.NewGuid().ToString("N"),
+                    ["item_type"] = "potion",
+                    ["gold_amount"] = 0,
+                    ["item_data"] = new Godot.Collections.Dictionary
+                    {
+                        ["item_id"] = "hp_potion_s",
+                        ["name"] = "Small HP Potion",
+                        ["description"] = "Restores 5 HP.",
+                        ["item_type"] = "potion",
+                        ["quantity"] = 1,
+                        ["price"] = 10,
+                        ["sprite_path"] = "res://Assets/items/hp_potion_S.png",
+                        ["heal_amount"] = 5,
+                        ["removes_burn"] = false
+                    }
+                });
+                break;
+
+            case AuthRequestKind.ClearDrops:
+                // ResponseCode 200 OK, empty Data/ArrayData is fine
                 break;
 
             case AuthRequestKind.Logout:

--- a/Scripts/Characters/Monster.cs
+++ b/Scripts/Characters/Monster.cs
@@ -769,19 +769,83 @@ namespace QuestFantasy.Characters
             parent.AddChild(expPickup);
             GD.PrintS($"[Monster] Spawned EXP drop at {expPickup.Position}");
 
+            DifficultyLevel mapDiff = _map != null ? _map.Difficulty : DifficultyLevel.Normal;
+            int playerLevel = _player != null ? (int)_player.Level : (int)Level;
+            var manager = FindEquipmentManager();
+
+            if (Main.Instance != null)
+            {
+                string token = Main.Instance.GetAuthToken();
+                if (Main.Instance.PlayerDataApiClient != null && !string.IsNullOrEmpty(token))
+                {
+                    Main.Instance.PlayerDataApiClient.GenerateDrops(token, playerLevel, "monster", mapDiff.ToString(), result => {
+                        if (result.NetworkOk && result.ResponseCode == 200 && result.ArrayData != null)
+                        {
+                            SpawnServerDrops(parent, GlobalPosition, manager, result.ArrayData);
+                        }
+                        else
+                        {
+                            GD.PrintErr("[Monster] Failed to generate secure drops from server. Falling back to local generation...");
+                            SpawnLocalDrops(parent, GlobalPosition, manager, mapDiff);
+                        }
+                    });
+                    return;
+                }
+            }
+
+            SpawnLocalDrops(parent, GlobalPosition, manager, mapDiff);
+        }
+
+        private void SpawnServerDrops(Node parent, Vector2 centerPosition, EquipmentManager manager, Godot.Collections.Array drops)
+        {
+            var rng = new RandomNumberGenerator();
+            rng.Randomize();
+
+            for (int i = 0; i < drops.Count; i++)
+            {
+                if (!(drops[i] is Godot.Collections.Dictionary drop))
+                {
+                    continue;
+                }
+
+                string instanceId = drop.Contains("instance_id") ? drop["instance_id"]?.ToString() : string.Empty;
+                string itemType = drop.Contains("item_type") ? drop["item_type"]?.ToString() : string.Empty;
+
+                if (itemType == "gold")
+                {
+                    int goldAmount = drop.Contains("gold_amount") ? Convert.ToInt32(drop["gold_amount"]) : 0;
+                    var coinDrop = new QuestFantasy.Items.CoinDrop();
+                    coinDrop.InitializeSecure(instanceId, goldAmount, _player);
+                    coinDrop.Position = centerPosition + new Vector2(rng.Randf() * 40f - 20f, rng.Randf() * 40f - 20f);
+                    parent.AddChild(coinDrop);
+                    GD.PrintS($"[Monster] Spawned Secure Coin drop of value {goldAmount} at {coinDrop.Position}");
+                }
+                else if (drop.Contains("item_data") && drop["item_data"] is Godot.Collections.Dictionary itemDataDict)
+                {
+                    itemDataDict["instance_id"] = instanceId;
+                    Item item = PlayerItemSnapshotCodec.Decode(itemDataDict);
+                    if (item != null)
+                    {
+                        float pscale = manager != null ? manager.PickupSpriteScale : 0.5f;
+                        var itemPos = centerPosition + new Vector2(rng.Randf() * 100f - 50f, rng.Randf() * 100f - 50f);
+                        LootItemFactory.SpawnPickup(parent, item, itemPos, pscale, "secure_monster");
+                        GD.PrintS($"[Monster] Spawned secure pickup: {item.Name} at {itemPos}");
+                    }
+                }
+            }
+        }
+
+        private void SpawnLocalDrops(Node parent, Vector2 centerPosition, EquipmentManager manager, DifficultyLevel mapDiff)
+        {
             var coinDrop = new QuestFantasy.Items.CoinDrop();
             int pLevel = _player != null ? (int)_player.Level : (int)Level;
-            DifficultyLevel mapDiff = _map != null ? _map.Difficulty : DifficultyLevel.Normal;
             coinDrop.Initialize(pLevel, mapDiff, 0.3f, _player);
-            coinDrop.Position = GlobalPosition + new Vector2((float)_random.NextDouble() * 40f - 20f, (float)_random.NextDouble() * 40f - 20f);
+            coinDrop.Position = centerPosition + new Vector2((float)_random.NextDouble() * 40f - 20f, (float)_random.NextDouble() * 40f - 20f);
             parent.AddChild(coinDrop);
             GD.PrintS($"[Monster] Spawned Coin drop at {coinDrop.Position}");
 
             var rng = new RandomNumberGenerator();
             rng.Randomize();
-
-            // Find EquipmentManager early so consumable/ticket drops can match equipment scale
-            var manager = FindEquipmentManager();
 
             float itemDropChance = Mathf.Clamp(ItemDropChance, 0f, 1f);
             if (rng.Randf() >= itemDropChance)
@@ -791,7 +855,6 @@ namespace QuestFantasy.Characters
             }
 
             Item itemDrop = RollSingleItemDrop(rng, manager, mapDiff);
-
             if (itemDrop == null)
             {
                 GD.PrintS("[Monster] Item drop roll passed, but no item was available.");
@@ -799,7 +862,7 @@ namespace QuestFantasy.Characters
             }
 
             float itemScale = manager != null ? manager.PickupSpriteScale : 0.5f;
-            var itemPos = GlobalPosition + new Vector2(rng.Randf() * 100f - 50f, rng.Randf() * 100f - 50f);
+            var itemPos = centerPosition + new Vector2(rng.Randf() * 100f - 50f, rng.Randf() * 100f - 50f);
             LootItemFactory.SpawnPickup(parent, itemDrop, itemPos, itemScale, "monster_item");
             GD.PrintS($"[Monster] Spawned item drop: {itemDrop.Name} at {itemPos}");
         }

--- a/Scripts/Characters/Monster.cs
+++ b/Scripts/Characters/Monster.cs
@@ -778,7 +778,8 @@ namespace QuestFantasy.Characters
                 string token = Main.Instance.GetAuthToken();
                 if (Main.Instance.PlayerDataApiClient != null && !string.IsNullOrEmpty(token))
                 {
-                    Main.Instance.PlayerDataApiClient.GenerateDrops(token, playerLevel, "monster", mapDiff.ToString(), result => {
+                    Main.Instance.PlayerDataApiClient.GenerateDrops(token, playerLevel, "monster", mapDiff.ToString(), result =>
+                    {
                         if (result.NetworkOk && result.ResponseCode == 200 && result.ArrayData != null)
                         {
                             SpawnServerDrops(parent, GlobalPosition, manager, result.ArrayData);

--- a/Scripts/Environment/TreasureChest.cs
+++ b/Scripts/Environment/TreasureChest.cs
@@ -111,33 +111,90 @@ public class TreasureChest : Node
     // Returns the list of spawned EquipmentPickup nodes.
     public Godot.Collections.Array OpenChest(Node parent, Vector2 centerPosition, EquipmentManager manager, int playerLevel)
     {
-        var spawned = new Godot.Collections.Array();
-        if (manager == null || parent == null)
-            return spawned;
+        DifficultyLevel mapDiff = DifficultyLevel.Normal;
+        if (parent is Map parentMap) mapDiff = parentMap.Difficulty;
 
+        if (Main.Instance != null)
+        {
+            string token = Main.Instance.GetAuthToken();
+            if (Main.Instance.PlayerDataApiClient != null && !string.IsNullOrEmpty(token))
+            {
+                Main.Instance.PlayerDataApiClient.GenerateDrops(token, playerLevel, "chest", mapDiff.ToString(), result => {
+                    if (result.NetworkOk && result.ResponseCode == 200 && result.ArrayData != null)
+                    {
+                        SpawnServerDrops(parent, centerPosition, manager, result.ArrayData);
+                    }
+                    else
+                    {
+                        GD.PrintErr("[TreasureChest] Failed to generate secure drops from server. Falling back to local generation...");
+                        SpawnLocalDrops(parent, centerPosition, manager, playerLevel, mapDiff);
+                    }
+                });
+                return new Godot.Collections.Array();
+            }
+        }
+
+        SpawnLocalDrops(parent, centerPosition, manager, playerLevel, mapDiff);
+        return new Godot.Collections.Array();
+    }
+
+    private void SpawnServerDrops(Node parent, Vector2 centerPosition, EquipmentManager manager, Godot.Collections.Array drops)
+    {
+        var rng = new RandomNumberGenerator();
+        rng.Randomize();
+
+        for (int i = 0; i < drops.Count; i++)
+        {
+            if (!(drops[i] is Godot.Collections.Dictionary drop))
+            {
+                continue;
+            }
+
+            string instanceId = drop.Contains("instance_id") ? drop["instance_id"]?.ToString() : string.Empty;
+            string itemType = drop.Contains("item_type") ? drop["item_type"]?.ToString() : string.Empty;
+
+            if (itemType == "gold")
+            {
+                int goldAmount = drop.Contains("gold_amount") ? Convert.ToInt32(drop["gold_amount"]) : 0;
+                var player = FindPlayerRecursive(parent);
+                var coinDrop = new QuestFantasy.Items.CoinDrop();
+                coinDrop.InitializeSecure(instanceId, goldAmount, player);
+                coinDrop.Position = centerPosition + new Vector2(rng.Randf() * 40f - 20f, rng.Randf() * 40f - 20f);
+                parent.AddChild(coinDrop);
+                GD.PrintS($"[TreasureChest] Spawned Secure Coin drop of value {goldAmount} at {coinDrop.Position}");
+            }
+            else if (drop.Contains("item_data") && drop["item_data"] is Godot.Collections.Dictionary itemDataDict)
+            {
+                itemDataDict["instance_id"] = instanceId;
+                Item item = PlayerItemSnapshotCodec.Decode(itemDataDict);
+                if (item != null)
+                {
+                    float pscale = manager != null ? manager.PickupSpriteScale : 0.5f;
+                    var offset = new Vector2(rng.Randf() * 200f - 100f, rng.Randf() * 200f - 100f);
+                    var itemPos = centerPosition + offset;
+                    LootItemFactory.SpawnPickup(parent, item, itemPos, pscale, "secure_chest");
+                    GD.PrintS($"[TreasureChest] Spawned secure pickup: {item.Name} at {itemPos}");
+                }
+            }
+        }
+    }
+
+    private void SpawnLocalDrops(Node parent, Vector2 centerPosition, EquipmentManager manager, int playerLevel, DifficultyLevel mapDiff)
+    {
         int minD = Math.Max(0, MinDrops);
         int maxD = Math.Max(minD, MaxDrops);
-        // Use RandomNumberGenerator to avoid casting overflow from GD.Randi
         var rng = new RandomNumberGenerator();
         rng.Randomize();
         int drops = rng.RandiRange(minD, maxD);
 
-        GD.PrintS($"[TreasureChest] drop range min={minD} max={maxD} -> drops={drops}");
-
-        // Use the provided manager to get equipment options (avoid relying on _manager field)
-        var options = manager.GetEquipmentSet(OptionCount, playerLevel, LevelOffset);
-        GD.PrintS($"[TreasureChest] Opening chest: drops={drops}, options={options.Count}");
-
-        // Convert options to a typed list
+        var options = manager != null ? manager.GetEquipmentSet(OptionCount, playerLevel, LevelOffset) : new System.Collections.Generic.List<Item>();
         var optList = new System.Collections.Generic.List<object>();
         foreach (var o in options)
         {
             optList.Add(o);
         }
 
-        // Shuffle optList and take unique items up to available count
         var shuffled = new System.Collections.Generic.List<object>(optList);
-        // Fisher-Yates shuffle
         for (int s = shuffled.Count - 1; s > 0; s--)
         {
             int j = rng.RandiRange(0, s);
@@ -155,11 +212,10 @@ public class TreasureChest : Node
 
             var pickup = new EquipmentPickup();
             pickup.ItemData = it;
-            pickup.SpriteScale = manager.PickupSpriteScale;
+            pickup.SpriteScale = manager != null ? manager.PickupSpriteScale : 0.1f;
             var offset = new Vector2(rng.Randf() * 200f - 100f, rng.Randf() * 200f - 100f);
             pickup.Position = centerPosition + offset;
 
-            // deterministic node name based on sprite/resource name
             string baseName = "equipment";
             var spriteTex = (pickup.ItemData is QuestFantasy.Core.Data.Items.Equipment pe) ? pe.Sprite : (pickup.ItemData is QuestFantasy.Core.Data.Items.Weapon pw ? pw.Sprite : null);
             if (spriteTex != null)
@@ -172,16 +228,7 @@ public class TreasureChest : Node
             }
             pickup.Name = $"Pickup_{baseName}_{i}";
             parent.AddChild(pickup);
-            spawned.Add(pickup);
-            GD.PrintS($"[TreasureChest] Spawned pickup: {pickup.Name} at {pickup.Position}");
-            if (pickup.ItemData == null || (pickup.ItemData is QuestFantasy.Core.Data.Items.Equipment e2 && e2.Sprite == null) || (pickup.ItemData is QuestFantasy.Core.Data.Items.Weapon w2 && w2.Sprite == null))
-            {
-                GD.PrintS($"[TreasureChest] WARNING: pickup {pickup.Name} has no sprite or item is null");
-            }
         }
-
-        DifficultyLevel mapDiff = DifficultyLevel.Normal;
-        if (parent is Map parentMap) mapDiff = parentMap.Difficulty;
 
         Item potionDrop = LootItemFactory.RollPotion(rng, 0.18f);
         if (potionDrop != null)
@@ -189,7 +236,6 @@ public class TreasureChest : Node
             var potionPos = centerPosition + new Vector2(rng.Randf() * 180f - 90f, rng.Randf() * 180f - 90f);
             float pscale = manager != null ? manager.PickupSpriteScale : 0.5f;
             LootItemFactory.SpawnPickup(parent, potionDrop, potionPos, pscale, "chest_potion");
-            GD.PrintS($"[TreasureChest] Spawned potion drop: {potionDrop.Name} at {potionPos}");
         }
 
         Item ticketDrop = LootItemFactory.RollTicket(rng, mapDiff, 2f);
@@ -198,17 +244,12 @@ public class TreasureChest : Node
             var ticketPos = centerPosition + new Vector2(rng.Randf() * 180f - 90f, rng.Randf() * 180f - 90f);
             float tscale = manager != null ? manager.PickupSpriteScale : 0.5f;
             LootItemFactory.SpawnPickup(parent, ticketDrop, ticketPos, tscale, "chest_ticket");
-            GD.PrintS($"[TreasureChest] Spawned ticket drop: {ticketDrop.Name} at {ticketPos}");
         }
 
-        // Spawn CoinDrop
         var player = FindPlayerRecursive(parent);
         var coinDrop = new QuestFantasy.Items.CoinDrop();
         coinDrop.Initialize(playerLevel, mapDiff, 1.0f, player);
         coinDrop.Position = centerPosition + new Vector2(rng.Randf() * 40f - 20f, rng.Randf() * 40f - 20f);
         parent.AddChild(coinDrop);
-        GD.PrintS($"[TreasureChest] Spawned Coin drop at {coinDrop.Position}");
-
-        return spawned;
     }
 }

--- a/Scripts/Environment/TreasureChest.cs
+++ b/Scripts/Environment/TreasureChest.cs
@@ -119,7 +119,8 @@ public class TreasureChest : Node
             string token = Main.Instance.GetAuthToken();
             if (Main.Instance.PlayerDataApiClient != null && !string.IsNullOrEmpty(token))
             {
-                Main.Instance.PlayerDataApiClient.GenerateDrops(token, playerLevel, "chest", mapDiff.ToString(), result => {
+                Main.Instance.PlayerDataApiClient.GenerateDrops(token, playerLevel, "chest", mapDiff.ToString(), result =>
+                {
                     if (result.NetworkOk && result.ResponseCode == 200 && result.ArrayData != null)
                     {
                         SpawnServerDrops(parent, centerPosition, manager, result.ArrayData);

--- a/Scripts/Items/CoinDrop.cs
+++ b/Scripts/Items/CoinDrop.cs
@@ -24,11 +24,23 @@ namespace QuestFantasy.Items
         private const float FrameDuration = 0.05f;
         private int _currentFrame = 0;
 
+        public string InstanceId { get; set; } = string.Empty;
+        public int Value => _value;
+
         public void Initialize(int playerLevel, DifficultyLevel difficulty, float entityMultiplier, Player player, float spawnDelay = 0f)
         {
             _player = player;
             _spawnTimer = spawnDelay;
             CalculateValue(playerLevel, difficulty, entityMultiplier);
+        }
+
+        public void InitializeSecure(string instanceId, int value, Player player, float spawnDelay = 0f)
+        {
+            _player = player;
+            _spawnTimer = spawnDelay;
+            InstanceId = instanceId;
+            _value = value;
+            GD.Print($"[CoinDrop] Securely initialized coin value: {_value} (ID: {InstanceId})");
         }
 
         private void CalculateValue(int playerLevel, DifficultyLevel difficulty, float entityMultiplier)
@@ -112,6 +124,11 @@ namespace QuestFantasy.Items
                     {
                         // Needs AddGold method on player or inventory system
                         _player.AddGold(_value);
+                        if (Main.Instance != null && !string.IsNullOrEmpty(InstanceId))
+                        {
+                            Main.Instance.ClaimDrop(InstanceId);
+                            Main.Instance.TransmitPlayerProfile("pickup_gold");
+                        }
                         QueueFree();
                         return;
                     }

--- a/Scripts/Main.cs
+++ b/Scripts/Main.cs
@@ -385,7 +385,8 @@ public class Main : Node2D
             return;
         }
         GD.Print("[ProgressSync] Cheated state or sync error detected. Force-fetching authoritative server profile to rollback...");
-        _playerDataApiClient.FetchPlayerProfile(token, res => {
+        _playerDataApiClient.FetchPlayerProfile(token, res =>
+        {
             if (res.NetworkOk && res.IsSuccessStatus(200))
             {
                 var snapshot = PlayerProfileSnapshot.FromDictionary(res.Data);
@@ -416,7 +417,7 @@ public class Main : Node2D
         _activeSyncMutationVersion = _localMutationVersion;
         var payload = snapshot.ToUpdatePayload(_syncSessionId, _syncSequence);
         payload["reason"] = reason;
-        
+
         var claimedArray = new Godot.Collections.Array();
         foreach (var claimId in _pendingClaimIds)
         {

--- a/Scripts/Main.cs
+++ b/Scripts/Main.cs
@@ -27,6 +27,24 @@ public class Main : Node2D
     private readonly EquipmentManager _equipManagerRef = new EquipmentManager();
     private readonly TreasureChest _chestRef = new TreasureChest();
     private readonly Godot.Collections.Array<Monster> _spawnedMonsters = new Godot.Collections.Array<Monster>();
+    public static Main Instance { get; private set; }
+    public AuthApiClient PlayerDataApiClient => _playerDataApiClient;
+    private readonly System.Collections.Generic.List<string> _pendingClaimIds = new System.Collections.Generic.List<string>();
+
+    public string GetAuthToken()
+    {
+        return _authFlowController?.CurrentSession?.Token;
+    }
+
+    public void ClaimDrop(string instanceId)
+    {
+        if (string.IsNullOrEmpty(instanceId)) return;
+        if (!_pendingClaimIds.Contains(instanceId))
+        {
+            _pendingClaimIds.Add(instanceId);
+        }
+    }
+
     private readonly string _syncSessionId = Guid.NewGuid().ToString("N");
     private int _syncSequence = 0;
     private int _localMutationVersion = 0;
@@ -52,6 +70,7 @@ public class Main : Node2D
 
     public override void _Ready()
     {
+        Instance = this;
         GD.Print("遊戲開始了，正在讀取登入畫面...");
         SetProcess(true);
         GetTree().Connect("node_added", this, nameof(OnSceneNodeAdded));
@@ -331,6 +350,12 @@ public class Main : Node2D
 
     private void HandleLoggedOut()
     {
+        string token = _authFlowController?.CurrentSession?.Token;
+        if (!string.IsNullOrEmpty(token) && _playerDataApiClient != null)
+        {
+            _playerDataApiClient.ClearDrops(token, null);
+        }
+
         _isProfileFetchPending = false;
         _profileFetchTimeoutTimer?.Stop();
         _progressIndicator?.SetState(ProgressSyncIndicator.SyncState.Hidden);
@@ -352,7 +377,26 @@ public class Main : Node2D
         GD.Print("[Main] Logged out - all game states cleaned");
     }
 
-    private void TransmitPlayerProfile(string reason)
+    private void FetchProfileAndRollback()
+    {
+        string token = _authFlowController?.CurrentSession?.Token;
+        if (string.IsNullOrWhiteSpace(token) || _playerDataApiClient == null)
+        {
+            return;
+        }
+        GD.Print("[ProgressSync] Cheated state or sync error detected. Force-fetching authoritative server profile to rollback...");
+        _playerDataApiClient.FetchPlayerProfile(token, res => {
+            if (res.NetworkOk && res.IsSuccessStatus(200))
+            {
+                var snapshot = PlayerProfileSnapshot.FromDictionary(res.Data);
+                GD.Print($"[ProgressSync] Authoritative profile loaded. Level={snapshot.Level}, HP={snapshot.HpCurrent}/{snapshot.HpMax}, EXP={snapshot.Experience}, Gold={snapshot.Gold}. Applying rollback...");
+                _player?.ApplyProfile(snapshot);
+                _pendingClaimIds.Clear();
+            }
+        });
+    }
+
+    public void TransmitPlayerProfile(string reason)
     {
         if (_player == null || _playerDataApiClient == null || _playerDataApiClient.IsBusy)
         {
@@ -372,7 +416,15 @@ public class Main : Node2D
         _activeSyncMutationVersion = _localMutationVersion;
         var payload = snapshot.ToUpdatePayload(_syncSessionId, _syncSequence);
         payload["reason"] = reason;
-        GD.Print($"[ProgressSync] Sending profile. reason={reason}, seq={_syncSequence}, level={snapshot.Level}, hp={snapshot.HpCurrent}/{snapshot.HpMax}, exp={snapshot.Experience}, gold={snapshot.Gold}.");
+        
+        var claimedArray = new Godot.Collections.Array();
+        foreach (var claimId in _pendingClaimIds)
+        {
+            claimedArray.Add(claimId);
+        }
+        payload["claimed_drops"] = claimedArray;
+
+        GD.Print($"[ProgressSync] Sending profile. reason={reason}, seq={_syncSequence}, level={snapshot.Level}, hp={snapshot.HpCurrent}/{snapshot.HpMax}, exp={snapshot.Experience}, gold={snapshot.Gold}. Claimed drops count: {claimedArray.Count}");
         _progressIndicator?.SetState(ProgressSyncIndicator.SyncState.Saving);
 
         if (!_playerDataApiClient.UpdatePlayerProfile(token, payload, OnPlayerProfileSynced))
@@ -388,7 +440,8 @@ public class Main : Node2D
         _progressIndicator?.SetState(ProgressSyncIndicator.SyncState.Hidden);
         if (!result.NetworkOk || !result.IsSuccessStatus(200) || _player == null)
         {
-            GD.PrintErr($"[ProgressSync] Sync failed. NetworkOk={result.NetworkOk}, Code={result.ResponseCode}, playerReady={_player != null}.");
+            GD.PrintErr($"[ProgressSync] Sync failed. NetworkOk={result.NetworkOk}, Code={result.ResponseCode}, playerReady={_player != null}. Force-rolling back local state...");
+            FetchProfileAndRollback();
             return;
         }
 
@@ -403,11 +456,15 @@ public class Main : Node2D
             }
 
             GD.Print($"[ProgressSync] Sync applied. Level={snapshot.Level}, HP={snapshot.HpCurrent}/{snapshot.HpMax}, EXP={snapshot.Experience}, Gold={snapshot.Gold}.");
+            _pendingClaimIds.Clear(); // Clear claims on successful sync
             _player.ApplyProfile(snapshot);
             return;
         }
 
         GD.Print($"[ProgressSync] Sync ignored by server. reason={snapshot.IgnoreReason}.");
+        // Force-rollback local cheated state to the valid server snapshot
+        _pendingClaimIds.Clear(); // Clear claims since we roll back
+        _player.ApplyProfile(snapshot);
     }
 
     private void DestroyPlayableWorld()
@@ -657,6 +714,12 @@ public class Main : Node2D
         // Sync to backend so the server has the latest state
         TransmitPlayerProfile("return_to_lobby");
 
+        string token = _authFlowController?.CurrentSession?.Token;
+        if (!string.IsNullOrEmpty(token) && _playerDataApiClient != null)
+        {
+            _playerDataApiClient.ClearDrops(token, null);
+        }
+
         DestroyPlayableWorld();
 
         // Rebuild the lobby for another session
@@ -736,6 +799,7 @@ public class Main : Node2D
             return;
         }
 
+        ClaimDrop(item.InstanceId);
         MarkLocalMutation();
         EquipmentPreview.Instance?.HidePreview();
         targetPickup.QueueFree();


### PR DESCRIPTION

This pull request introduces a secure, server-authoritative system for generating and claiming item and gold drops from monsters and treasure chests. It adds new API endpoints and client logic to request drop data from the backend, updates the drop spawning flow to use server data when available, and ensures that gold pickups are properly claimed and reported. If the server is unavailable, local fallback logic is used to generate drops as before.

**Secure Drop Generation and Claiming**

* Adds new API endpoints and client methods:
  * `AuthApiClient` now supports `GenerateDrops` and `ClearDrops` requests, enabling secure drop generation and cleanup via the backend. [[1]](diffhunk://#diff-ca8c6028d27d9df13fa206ca26b354b20d9bcbc0b20866de0131ca958180aa3aL251-R253) [[2]](diffhunk://#diff-ca8c6028d27d9df13fa206ca26b354b20d9bcbc0b20866de0131ca958180aa3aR455-R487)
  * Mock server responses are implemented for these endpoints to facilitate local testing.

* Integrates server-driven drop generation:
  * `Monster` and `TreasureChest` now request drops from the server when possible, and only fall back to local generation if the server is unavailable or returns an error. [[1]](diffhunk://#diff-46522c4a70c8e00c6b266186f670bf2f0d7d1bd7f80a180b1a31c443cc13951fR772-L785) [[2]](diffhunk://#diff-058b6b4d72ec0e55fd36bc94e05485db5b57dbf6d8e057396a7ce83e90c8898eL114-L140)
  * Drops from the server are spawned with their server-assigned `instance_id` and data, supporting both gold and item drops. [[1]](diffhunk://#diff-46522c4a70c8e00c6b266186f670bf2f0d7d1bd7f80a180b1a31c443cc13951fR772-L785) [[2]](diffhunk://#diff-058b6b4d72ec0e55fd36bc94e05485db5b57dbf6d8e057396a7ce83e90c8898eL114-L140)
  * Local drop logic is refactored to use the provided spawn position and manager, and to match the new secure drop flow. [[1]](diffhunk://#diff-058b6b4d72ec0e55fd36bc94e05485db5b57dbf6d8e057396a7ce83e90c8898eL158-L162) [[2]](diffhunk://#diff-058b6b4d72ec0e55fd36bc94e05485db5b57dbf6d8e057396a7ce83e90c8898eL175-L192) [[3]](diffhunk://#diff-058b6b4d72ec0e55fd36bc94e05485db5b57dbf6d8e057396a7ce83e90c8898eL201-L212)

**Gold Drop Claiming and Profile Sync**

* Adds support for tracking and claiming gold drops:
  * `CoinDrop` now supports secure initialization with an `instance_id` and value, and notifies the main game instance when picked up. [[1]](diffhunk://#diff-cdd268e01acd0baa70d86233f42c4ec3f6c3f879d3c7a8494cbc19bb397d3145R27-R45) [[2]](diffhunk://#diff-cdd268e01acd0baa70d86233f42c4ec3f6c3f879d3c7a8494cbc19bb397d3145R127-R131)
  * `Main` tracks pending claimed drop IDs and provides methods for claiming drops and transmitting the player's profile after pickup.

**Session and Cleanup Handling**

* Ensures cleanup of pending drops on logout:
  * When the player logs out, all pending drops are cleared via the `ClearDrops` API call.

**Other Improvements**

* Adds a singleton reference to `Main.Instance` for easier access to global state and API clients. [[1]](diffhunk://#diff-df511da3d5233a28bc640a89a749b3866311e3b15fd94ca0791e36184e1a509fR30-R47) [[2]](diffhunk://#diff-df511da3d5233a28bc640a89a749b3866311e3b15fd94ca0791e36184e1a509fR73)
* Minor fixes for null checks, manager usage, and consistent item scaling in drop spawning.

These changes provide a more secure and authoritative item drop system while maintaining robust fallback behavior for offline or local play.